### PR TITLE
Expand to support policy schema

### DIFF
--- a/cmd/vulticheck/main.go
+++ b/cmd/vulticheck/main.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	policyPath := flag.String("policy", "", "Path to the policy.json file")
+	schemaPath := flag.String("schema", "", "Path to the schema.json file")
 	txHex := flag.String("tx", "", "Hex-encoded transaction string")
 	chainID := flag.String("chain", "ethereum", "Chain ID (e.g., 'ethereum', 'bitcoin')")
 	flag.Parse()
@@ -38,7 +39,23 @@ func main() {
 	}
 	log.Printf("Successfully loaded policy: %s (Name: %s)\n", policy.GetId(), policy.GetName())
 
-	// 2. Initialize Chain based on chainID flag
+	// 2. Load and Parse Schema (if path given)
+	var schema *types.RecipeSchema
+	if *schemaPath != "" {
+		schemaFileBytes, err := os.ReadFile(*schemaPath)
+		if err != nil {
+			log.Fatalf("Failed to read schema file %s: %v", *schemaPath, err)
+		}
+
+		schema = &types.RecipeSchema{}
+		if err := protojson.Unmarshal(schemaFileBytes, schema); err != nil {
+			log.Fatalf("Failed to unmarshal schema JSON: %v", err)
+		}
+		log.Printf("Successfully loaded schema for plugin: %s (Version: %d)",
+			schema.GetPluginName(), schema.GetPluginVersion())
+	}
+
+	// 3. Initialize Chain based on chainID flag
 	selectedChain, err := chain.GetChain(*chainID)
 	if err != nil {
 		log.Fatalf("Failed to get chain %s: %v", *chainID, err)

--- a/cmd/vulticheck/main.go
+++ b/cmd/vulticheck/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	eng := engine.NewEngine()
 	eng.SetLogger(log.Default())
-	transactionAllowedByPolicy, matchingRule, err := eng.Evaluate(&policy, selectedChain, decodedTx)
+	transactionAllowedByPolicy, matchingRule, err := eng.Evaluate(&policy, schema, selectedChain, decodedTx)
 	if err != nil {
 		log.Printf("Failed to evaluate transaction: %v", err)
 	}

--- a/testdata/payroll_schema.json
+++ b/testdata/payroll_schema.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "schedule_version": 1,
+  "plugin_id": "vultisig_transfer_0001",
+  "plugin_name": "Payroll Test ETH Transfer Only",
+  "plugin_version": 1,
+  "supported_resources": [
+    {
+      "resource_path": {
+        "chain_id": "ethereum",
+        "protocol_id": "eth",
+        "function_id": "transfer",
+        "full": "ethereum.eth.transfer"
+      },
+      "parameter_capabilities": [
+        {
+          "parameter_name": "recipient",
+          "supported_types": [
+            "CONSTRAINT_TYPE_FIXED",
+            "CONSTRAINT_TYPE_WHITELIST"
+          ],
+          "required": true
+        },
+        {
+          "parameter_name": "amount",
+          "supported_types": [
+            "CONSTRAINT_TYPE_FIXED",
+            "CONSTRAINT_TYPE_MAX",
+            "CONSTRAINT_TYPE_RANGE"
+          ],
+          "required": true
+        }
+      ],
+      "required": true
+    }
+  ],
+  "scheduling": {
+    "supports_scheduling": false,
+    "supported_frequencies": [],
+    "max_scheduled_executions": 0
+  },
+  "requirements": {
+    "min_vultisig_version": 1,
+    "supported_chains": ["ethereum"]
+  }
+}


### PR DESCRIPTION
This PR expands vulticheck to accept schema json for plugins, so that rules can be skipped if the resources are not supported. 