### PR TITLE
cannot unmarshal hex number with leading zero error

### DIFF
--- a/sdk/evm/evm.go
+++ b/sdk/evm/evm.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	reth "github.com/vultisig/recipes/ethereum"
@@ -257,23 +257,25 @@ func (sdk *SDK) estimateTx(
 
 	gasTipCapHex := "0x0"
 	if gasTipCap != nil {
-		gasTipCapHex = "0x" + common.Bytes2Hex(gasTipCap.Bytes())
+		gasTipCapHex = hexutil.EncodeBig(gasTipCap)
 	}
 
 	maxFeePerGasHex := "0x0"
 	if maxFeePerGas != nil {
-		maxFeePerGasHex = "0x" + common.Bytes2Hex(maxFeePerGas.Bytes())
+		maxFeePerGasHex = hexutil.EncodeBig(maxFeePerGas)
 	}
 
 	valueHex := "0x0"
 	if value != nil {
-		valueHex = "0x" + common.Bytes2Hex(value.Bytes())
+		valueHex = hexutil.EncodeBig(value)
 	}
 
 	var dataHex string // omitempty in JSON
 	if data != nil {
-		dataHex = "0x" + common.Bytes2Hex(data)
+		dataHex = hexutil.Encode(data)
 	}
+
+	gas := hexutil.EncodeUint64(gasLimit)
 
 	var callRes createAccessListRes
 	err = sdk.rpcClientRaw.CallContext(
@@ -283,7 +285,7 @@ func (sdk *SDK) estimateTx(
 		createAccessListArgs{
 			From:                 from.Hex(),
 			To:                   to.Hex(),
-			Gas:                  "0x" + strconv.FormatUint(gasLimit, 16),
+			Gas:                  gas,
 			MaxPriorityFeePerGas: gasTipCapHex,
 			MaxFeePerGas:         maxFeePerGasHex,
 			Value:                valueHex,

--- a/sdk/evm/evm_test.go
+++ b/sdk/evm/evm_test.go
@@ -3,12 +3,12 @@ package evm
 import (
 	"context"
 	"math/big"
-	"strconv"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/mock"
@@ -65,11 +65,11 @@ func TestSDK_MakeTx_unit(t *testing.T) {
 			createAccessListArgs{
 				From:                 from.Hex(),
 				To:                   to.Hex(),
-				Gas:                  "0x" + strconv.FormatUint(gasLimit, 16),
-				MaxPriorityFeePerGas: "0x" + common.Bytes2Hex(gasTipCap.Bytes()),
-				MaxFeePerGas:         "0x" + common.Bytes2Hex(gasFeeCap.Bytes()),
-				Value:                "0x" + common.Bytes2Hex(value.Bytes()),
-				Data:                 "0x" + common.Bytes2Hex(data),
+				Gas:                  hexutil.EncodeUint64(gasLimit),
+				MaxPriorityFeePerGas: hexutil.EncodeBig(gasTipCap),
+				MaxFeePerGas:         hexutil.EncodeBig(gasFeeCap),
+				Value:                hexutil.EncodeBig(value),
+				Data:                 hexutil.Encode(data),
 			},
 			"latest",
 		},


### PR DESCRIPTION
This PR addresses an issue where manually encoded hex strings for maxPriorityFeePerGas, maxFeePerGas, and value could include leading zeroes (e.g. 0x0123), which are invalid in Ethereum's JSON-RPC spec and cause errors like:

It's a common issue across multiple languages, essentially numbers cannot have a leading 0, so the number 7 must be `0x7` and not `0x07`. Luckily the fix is straightforward

```
json: cannot unmarshal hex number with leading zero digits into Go struct field CallArgs.maxPriorityFeePerGas of type *hexutil.Big
```

### Changes:
Replaced manual hex encoding (common.Bytes2Hex) with hexutil.EncodeBig to ensure proper formatting of big.Int values.

Ensured all values passed to eth_createAccessList are RPC-compliant.

### Impact:
Prevents intermittent unmarshalling errors during fee estimation and access list creation.

Let me know if you’d like it tailored to include a ticket number, reviewer tag, or internal references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized hexadecimal encoding for transaction parameters using a dedicated encoding library, resulting in more consistent and reliable formatting.

* **Tests**
  * Updated tests to use the new encoding approach, ensuring continued accuracy in transaction parameter serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->