### PR TITLE
Magic const THORCHAIN_VAULT

### DIFF
--- a/proto/constraint.proto
+++ b/proto/constraint.proto
@@ -18,6 +18,7 @@ enum ConstraintType {
 enum MagicConstant {
   UNSPECIFIED = 0;
   VULTISIG_TREASURY = 1;
+  THORCHAIN_VAULT = 2;
 }
 
 // Constraint defines restrictions on a parameter

--- a/resolver/registry.go
+++ b/resolver/registry.go
@@ -17,6 +17,7 @@ func NewMagicConstantRegistry() *MagicConstantRegistry {
 
 	// Register all resolvers
 	registry.Register(NewDefaultTreasuryResolver())
+	registry.Register(NewTHORChainVaultResolver())
 
 	return registry
 }

--- a/resolver/thorchain_vault.go
+++ b/resolver/thorchain_vault.go
@@ -1,0 +1,124 @@
+package resolver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/vultisig/recipes/types"
+)
+
+type THORChainVaultResolver struct {
+	client  *http.Client
+	baseURL string
+}
+
+// InboundAddress represents a single inbound address from THORChain API
+type InboundAddress struct {
+	Chain   string `json:"chain"`
+	PubKey  string `json:"pub_key"`
+	Address string `json:"address"`
+	Router  string `json:"router,omitempty"`
+	Halted  bool   `json:"halted"`
+	GasRate string `json:"gas_rate"`
+}
+
+// NewTHORChainVaultResolver creates a new resolver for THORChain Asgard vault addresses
+func NewTHORChainVaultResolver() Resolver {
+	return &THORChainVaultResolver{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		baseURL: "https://thornode.ninerealms.com",
+	}
+}
+
+func (r *THORChainVaultResolver) Supports(constant types.MagicConstant) bool {
+	return constant == types.MagicConstant_THORCHAIN_VAULT
+}
+
+// Resolve converts THORCHAIN_VAULT magic constant to current Asgard vault address
+func (r *THORChainVaultResolver) Resolve(constant types.MagicConstant, chainID, assetID string) (string, string, error) {
+	if !r.Supports(constant) {
+		return "", "", fmt.Errorf("THORChainVaultResolver does not support type: %v", constant)
+	}
+
+	// Query THORChain inbound addresses API
+	inboundAddresses, err := r.getInboundAddresses()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get THORChain inbound addresses: %w", err)
+	}
+
+	// Find the address for the requested chain
+	address, err := r.findAddressForChain(inboundAddresses, chainID)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to find address for chain %s: %w", chainID, err)
+	}
+
+	return address, "", nil
+}
+
+// getInboundAddresses queries the THORChain API for current inbound addresses
+func (r *THORChainVaultResolver) getInboundAddresses() ([]InboundAddress, error) {
+	url := r.baseURL + "/thorchain/inbound_addresses"
+
+	resp, err := r.client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var inboundAddresses []InboundAddress
+	if err := json.Unmarshal(body, &inboundAddresses); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	return inboundAddresses, nil
+}
+
+// findAddressForChain finds the inbound address for a specific chain
+func (r *THORChainVaultResolver) findAddressForChain(addresses []InboundAddress, chainID string) (string, error) {
+	// Normalize chainID to uppercase for comparison (THORChain uses uppercase)
+	normalizedChainID := strings.ToUpper(chainID)
+
+	// Handle common chain ID mappings
+	chainMap := map[string]string{
+		"ETHEREUM":  "ETH",
+		"ETH":       "ETH",
+		"BITCOIN":   "BTC",
+		"BTC":       "BTC",
+		"AVALANCHE": "AVAX",
+		"AVAX":      "AVAX",
+		"BASE":      "BASE",
+	}
+
+	if mapped, exists := chainMap[normalizedChainID]; exists {
+		normalizedChainID = mapped
+	} else {
+		return "", fmt.Errorf("chain %s is not supported by this resolver", chainID)
+	}
+
+	// Find the address for the chain
+	for _, addr := range addresses {
+		if strings.ToUpper(addr.Chain) == normalizedChainID {
+			if addr.Halted {
+				return "", fmt.Errorf("inbound address for chain %s is currently halted", chainID)
+			}
+			return addr.Address, nil
+		}
+	}
+
+	return "", fmt.Errorf("no inbound address found for chain %s", chainID)
+}

--- a/resolver/thorchain_vault.go
+++ b/resolver/thorchain_vault.go
@@ -109,6 +109,11 @@ func (r *THORChainVaultResolver) findAddressForChain(addresses []InboundAddress,
 			if addr.Halted {
 				return "", fmt.Errorf("inbound address for chain %s is currently halted", chainID)
 			}
+			
+			// For EVM chains, use router if available, otherwise use vault address
+			if chain.IsEvm() && addr.Router != "" {
+				return addr.Router, nil
+			}
 			return addr.Address, nil
 		}
 	}

--- a/resolver/thorchain_vault_test.go
+++ b/resolver/thorchain_vault_test.go
@@ -1,0 +1,265 @@
+package resolver
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vultisig/recipes/types"
+)
+
+func TestTHORChainVaultResolver_Supports(t *testing.T) {
+	resolver := NewTHORChainVaultResolver()
+
+	tests := []struct {
+		name     string
+		constant types.MagicConstant
+		expected bool
+	}{
+		{
+			name:     "supports THORCHAIN_VAULT",
+			constant: types.MagicConstant_THORCHAIN_VAULT,
+			expected: true,
+		},
+		{
+			name:     "does not support VULTISIG_TREASURY",
+			constant: types.MagicConstant_VULTISIG_TREASURY,
+			expected: false,
+		},
+		{
+			name:     "does not support UNSPECIFIED",
+			constant: types.MagicConstant_UNSPECIFIED,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolver.Supports(tt.constant)
+			if result != tt.expected {
+				t.Errorf("Supports(%v) = %v, expected %v", tt.constant, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTHORChainVaultResolver_Resolve_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	resolver := NewTHORChainVaultResolver()
+
+	tests := []struct {
+		name    string
+		chainID string
+		assetID string
+		wantErr bool
+	}{
+		{
+			name:    "resolve BTC vault address",
+			chainID: "bitcoin",
+			assetID: "btc",
+			wantErr: false,
+		},
+		{
+			name:    "resolve ETH vault address",
+			chainID: "ethereum",
+			assetID: "eth",
+			wantErr: false,
+		},
+		{
+			name:    "resolve Base vault address",
+			chainID: "base",
+			assetID: "eth",
+			wantErr: false,
+		},
+		{
+			name:    "resolve using uppercase chain",
+			chainID: "BTC",
+			assetID: "btc",
+			wantErr: false,
+		},
+		{
+			name:    "unsupported chain BSC should error",
+			chainID: "bscchain",
+			assetID: "bnb",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported chain Arbitrum should error",
+			chainID: "arbitrum",
+			assetID: "eth",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported chain should error",
+			chainID: "unsupported_chain",
+			assetID: "token",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, memo, err := resolver.Resolve(
+				types.MagicConstant_THORCHAIN_VAULT,
+				tt.chainID,
+				tt.assetID,
+			)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error for chainID %s, but got none", tt.chainID)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error for chainID %s: %v", tt.chainID, err)
+				return
+			}
+
+			if address == "" {
+				t.Errorf("Expected non-empty address for chainID %s", tt.chainID)
+			}
+
+			// THORChain vault addresses should not have memos
+			if memo != "" {
+				t.Errorf("Expected empty memo, got: %s", memo)
+			}
+
+			t.Logf("Successfully resolved %s vault address: %s", tt.chainID, address)
+		})
+	}
+}
+
+func TestTHORChainVaultResolver_UnsupportedConstant(t *testing.T) {
+	resolver := NewTHORChainVaultResolver()
+
+	_, _, err := resolver.Resolve(
+		types.MagicConstant_VULTISIG_TREASURY,
+		"bitcoin",
+		"btc",
+	)
+
+	if err == nil {
+		t.Error("Expected error for unsupported magic constant")
+	}
+
+	expectedError := "THORChainVaultResolver does not support type"
+	if err != nil && len(err.Error()) > 0 && err.Error()[:len(expectedError)] != expectedError {
+		t.Errorf("Expected error message to start with '%s', got: %s", expectedError, err.Error())
+	}
+}
+
+func TestTHORChainVaultResolver_UnsupportedChainError(t *testing.T) {
+	resolver := NewTHORChainVaultResolver()
+
+	// Test that unsupported chains return immediate error without API call
+	_, _, err := resolver.Resolve(
+		types.MagicConstant_THORCHAIN_VAULT,
+		"polygon", // Not in our supported chainMap
+		"matic",
+	)
+
+	if err == nil {
+		t.Error("Expected error for unsupported chain polygon")
+		return
+	}
+
+	expectedError := "chain polygon is not supported by this resolver"
+	if !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Expected error message to contain '%s', got: %s", expectedError, err.Error())
+	}
+}
+
+func TestTHORChainVaultResolver_APIConsistency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping API consistency test in short mode")
+	}
+
+	// Query THORChain API directly
+	apiAddresses, err := queryTHORChainAPIDirect()
+	if err != nil {
+		t.Fatalf("Failed to query THORChain API directly: %v", err)
+	}
+
+	// Create our resolver
+	resolver := NewTHORChainVaultResolver()
+
+	// Test each supported chain
+	supportedChains := []struct {
+		chainID       string
+		thorchainName string
+	}{
+		{"ethereum", "ETH"},
+		{"bitcoin", "BTC"},
+		{"base", "BASE"},
+	}
+
+	for _, chain := range supportedChains {
+		t.Run(chain.chainID, func(t *testing.T) {
+			// Get address from our resolver
+			resolverAddress, _, err := resolver.Resolve(
+				types.MagicConstant_THORCHAIN_VAULT,
+				chain.chainID,
+				"asset", // assetID doesn't matter for vault resolution
+			)
+			if err != nil {
+				t.Fatalf("Resolver failed for %s: %v", chain.chainID, err)
+			}
+
+			// Find the corresponding address from direct API call
+			var apiAddress string
+			for _, addr := range apiAddresses {
+				if strings.ToUpper(addr.Chain) == chain.thorchainName {
+					apiAddress = addr.Address
+					break
+				}
+			}
+
+			if apiAddress == "" {
+				t.Fatalf("No API address found for THORChain chain %s", chain.thorchainName)
+			}
+
+			// Compare addresses
+			if resolverAddress != apiAddress {
+				t.Errorf("Address mismatch for %s:\n  Resolver: %s\n  API:      %s",
+					chain.chainID, resolverAddress, apiAddress)
+			} else {
+				t.Logf("✓ %s addresses match: %s", chain.chainID, resolverAddress)
+			}
+		})
+	}
+}
+
+// Query the THORChain API directly for comparison
+func queryTHORChainAPIDirect() ([]InboundAddress, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	resp, err := client.Get("https://thornode.ninerealms.com/thorchain/inbound_addresses")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var addresses []InboundAddress
+	if err := json.Unmarshal(body, &addresses); err != nil {
+		return nil, err
+	}
+
+	return addresses, nil
+}

--- a/resolver/thorchain_vault_test.go
+++ b/resolver/thorchain_vault_test.go
@@ -79,7 +79,7 @@ func TestTHORChainVaultResolver_Resolve_Integration(t *testing.T) {
 		},
 		{
 			name:    "resolve using uppercase chain",
-			chainID: "BTC",
+			chainID: "bitcoin",
 			assetID: "btc",
 			wantErr: false,
 		},
@@ -171,7 +171,7 @@ func TestTHORChainVaultResolver_UnsupportedChainError(t *testing.T) {
 		return
 	}
 
-	expectedError := "chain polygon is not supported by this resolver"
+	expectedError := "chain Polygon not supported by ThorChain"
 	if !strings.Contains(err.Error(), expectedError) {
 		t.Errorf("Expected error message to contain '%s', got: %s", expectedError, err.Error())
 	}

--- a/types/constraint.pb.go
+++ b/types/constraint.pb.go
@@ -88,6 +88,7 @@ type MagicConstant int32
 const (
 	MagicConstant_UNSPECIFIED       MagicConstant = 0
 	MagicConstant_VULTISIG_TREASURY MagicConstant = 1
+	MagicConstant_THORCHAIN_VAULT   MagicConstant = 2
 )
 
 // Enum value maps for MagicConstant.
@@ -95,10 +96,12 @@ var (
 	MagicConstant_name = map[int32]string{
 		0: "UNSPECIFIED",
 		1: "VULTISIG_TREASURY",
+		2: "THORCHAIN_VAULT",
 	}
 	MagicConstant_value = map[string]int32{
 		"UNSPECIFIED":       0,
 		"VULTISIG_TREASURY": 1,
+		"THORCHAIN_VAULT":   2,
 	}
 )
 
@@ -321,10 +324,11 @@ const file_constraint_proto_rawDesc = "" +
 	"\x13CONSTRAINT_TYPE_MIN\x10\x03\x12\"\n" +
 	"\x1eCONSTRAINT_TYPE_MAGIC_CONSTANT\x10\x04\x12\x17\n" +
 	"\x13CONSTRAINT_TYPE_ANY\x10\x05\x12\x1a\n" +
-	"\x16CONSTRAINT_TYPE_REGEXP\x10\x06*7\n" +
+	"\x16CONSTRAINT_TYPE_REGEXP\x10\x06*L\n" +
 	"\rMagicConstant\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x15\n" +
-	"\x11VULTISIG_TREASURY\x10\x01B#Z!github.com/vultisig/recipes/typesb\x06proto3"
+	"\x11VULTISIG_TREASURY\x10\x01\x12\x13\n" +
+	"\x0fTHORCHAIN_VAULT\x10\x02B#Z!github.com/vultisig/recipes/typesb\x06proto3"
 
 var (
 	file_constraint_proto_rawDescOnce sync.Once


### PR DESCRIPTION
## Overview
Adds support for THORCHAIN_VAULT magic constant to dynamically resolve current ThorChain inbound addresses for cross-chain operations.

## Changes Made
- Protocol Buffer Updates
- Added THORCHAIN_VAULT = 2 to MagicConstant enum in proto/constraint.proto
- Regenerated protobuf files

## New Resolver Implementation
- Created THORChainVaultResolver in resolver/thorchain_vault.go
- Fetches live inbound addresses from ThorChain API endpoints
- Maps chain IDs (bitcoin, ethereum, etc.) to ThorChain symbols (BTC, ETH, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for resolving THORChain Vault deposit addresses across multiple chains (e.g., Bitcoin, Ethereum, Base).
  * Resolver automatically registered for immediate availability.
  * Clearer user-facing errors for unsupported chains or constants.

* **Tests**
  * Added tests for supported/unsupported constants and chains.
  * Integration checks comparing resolver results with live THORChain data (skipped in short mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->