### PR TITLE
Change XRP chain name to Ripple

### DIFF
--- a/engine/xrpl/xrpl_test.go
+++ b/engine/xrpl/xrpl_test.go
@@ -42,7 +42,7 @@ func TestXRPL_Evaluate_WrongProtocol(t *testing.T) {
 	xrpl := NewXRPL()
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 	}
 
 	err := xrpl.Evaluate(rule, []byte("any-data"))
@@ -55,7 +55,7 @@ func TestXRPL_Evaluate_UnsupportedFunction(t *testing.T) {
 	xrpl := NewXRPL()
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 	}
 
 	err := xrpl.Evaluate(rule, []byte("any-data"))
@@ -68,7 +68,7 @@ func TestXRPL_Evaluate_InvalidTransactionData(t *testing.T) {
 	xrpl := NewXRPL()
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 	}
 
 	err := xrpl.Evaluate(rule, []byte("invalid-tx-data"))
@@ -202,7 +202,7 @@ func TestXRPL_Evaluate_Success(t *testing.T) {
 	// Create a rule with parameter constraints matching the example policy structure
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{
@@ -254,7 +254,7 @@ func TestXRPL_MagicConstant_THORChainVault(t *testing.T) {
 	// won't match THORChain's vault address, but it tests the resolution mechanism)
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_MAGIC_CONSTANT,
 			Target: &types.Target_MagicConstant{
@@ -296,7 +296,7 @@ func TestXRPL_Evaluate_Failure(t *testing.T) {
 	// Create a rule with WRONG recipient and WRONG amount constraints
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{
@@ -364,7 +364,7 @@ func TestXRPL_Evaluate_Failure_ParameterConstraints(t *testing.T) {
 	// Create a rule with correct target but wrong parameter constraints
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		// Correct target so we get to parameter validation
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
@@ -418,7 +418,7 @@ func TestXRPL_Evaluate_Swap_Success(t *testing.T) {
 	// Create a rule that validates the swap
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{
@@ -475,7 +475,7 @@ func TestXRPL_Evaluate_Swap_WrongTarget(t *testing.T) {
 	// Create rule with WRONG target address
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{
@@ -512,7 +512,7 @@ func TestXRPL_Evaluate_Swap_WrongAsset(t *testing.T) {
 	// Create rule with correct target but WRONG asset constraints
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{
@@ -549,7 +549,7 @@ func TestXRPL_Evaluate_Swap_AmountTooHigh(t *testing.T) {
 	// Create rule with correct target but amount constraint that's too restrictive
 	rule := &types.Rule{
 		Effect:   types.Effect_EFFECT_ALLOW,
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/kaptinlin/jsonschema v0.4.6
 	github.com/stretchr/testify v1.10.0
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/vultisig-go v0.0.0-20250818095937-af97443fcbbe
+	github.com/vultisig/vultisig-go v0.0.0-20251004125942-60b3b1898d15
 	github.com/xyield/xrpl-go v0.0.0-20230914223425-9abe75c05830
 	golang.org/x/sync v0.14.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -386,8 +386,8 @@ github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778 h1:XJ1hoo37JKG
 github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778/go.mod h1:UMc5q0Myab+BvzAe67UQrXTXwKGYNxK7bky7DJM+dl8=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/vultisig-go v0.0.0-20250818095937-af97443fcbbe h1:wPXoiswP3HP68g9TbI7GN8Xd8I3M/IbzOs2dypDpH6Y=
-github.com/vultisig/vultisig-go v0.0.0-20250818095937-af97443fcbbe/go.mod h1:jOf+2n1Eo/XZjiUbHjTfraPMw4HAZZ0Sw9Z6+vpQrU4=
+github.com/vultisig/vultisig-go v0.0.0-20251004125942-60b3b1898d15 h1:wdRFnDMLdbaWXExUR/88WBAZ9sY9i9ldzurrYJWQeuw=
+github.com/vultisig/vultisig-go v0.0.0-20251004125942-60b3b1898d15/go.mod h1:jOf+2n1Eo/XZjiUbHjTfraPMw4HAZZ0Sw9Z6+vpQrU4=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=

--- a/internal/metarule/metarule.go
+++ b/internal/metarule/metarule.go
@@ -546,7 +546,7 @@ func (m *MetaRule) handleXRP(in *types.Rule, r *types.ResourcePath) ([]*types.Ru
 		}
 
 		out := proto.Clone(in).(*types.Rule)
-		out.Resource = "xrp.xrp.transfer"
+		out.Resource = "ripple.xrp.transfer"
 		out.Target = &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_UNSPECIFIED,
 		}
@@ -570,7 +570,7 @@ func (m *MetaRule) handleXRP(in *types.Rule, r *types.ResourcePath) ([]*types.Ru
 		}
 
 		out := proto.Clone(in).(*types.Rule)
-		out.Resource = "xrp.swap"
+		out.Resource = "ripple.swap"
 		out.Target = &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_MAGIC_CONSTANT,
 			Target: &types.Target_MagicConstant{

--- a/internal/metarule/metarule_test.go
+++ b/internal/metarule/metarule_test.go
@@ -1133,7 +1133,7 @@ func TestTryFormat_XRPSend(t *testing.T) {
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "recipient",
@@ -1160,7 +1160,7 @@ func TestTryFormat_XRPSend(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
-	assert.Equal(t, "xrp.xrp.transfer", result[0].Resource)
+	assert.Equal(t, "ripple.xrp.transfer", result[0].Resource)
 	assert.Equal(t, types.TargetType_TARGET_TYPE_UNSPECIFIED, result[0].Target.TargetType)
 	require.Len(t, result[0].ParameterConstraints, 2)
 
@@ -1185,13 +1185,13 @@ func TestTryFormat_XRPSwap(t *testing.T) {
 		toChain          = "ethereum"
 		toAsset          = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
 		toAddress        = "0x742d35Cc6634C0532925a3b8D5c9E0B0Cf8a6b"
-		expectedResource = "xrp.swap"
+		expectedResource = "ripple.swap"
 	)
 
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "from_asset",
@@ -1282,7 +1282,7 @@ func TestTryFormat_XRPSend_MissingRecipient(t *testing.T) {
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "amount",
@@ -1305,7 +1305,7 @@ func TestTryFormat_XRPSend_MissingAmount(t *testing.T) {
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "recipient",
@@ -1328,7 +1328,7 @@ func TestTryFormat_XRPSwap_MissingFromAsset(t *testing.T) {
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.swap",
+		Resource: "ripple.swap",
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "from_address",
@@ -1351,7 +1351,7 @@ func TestTryFormat_XRPSend_MagicConstantRecipient(t *testing.T) {
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.send",
+		Resource: "ripple.send",
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "recipient",
@@ -1378,7 +1378,7 @@ func TestTryFormat_XRPSend_MagicConstantRecipient(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
-	assert.Equal(t, "xrp.xrp.transfer", result[0].Resource)
+	assert.Equal(t, "ripple.xrp.transfer", result[0].Resource)
 	assert.Equal(t, types.TargetType_TARGET_TYPE_UNSPECIFIED, result[0].Target.TargetType)
 	require.Len(t, result[0].ParameterConstraints, 2)
 
@@ -1397,7 +1397,7 @@ func TestTryFormat_XRP_NonMetaRule(t *testing.T) {
 
 	// Test with a complete XRP rule that has function ID (not a meta-rule)
 	rule := &types.Rule{
-		Resource: "xrp.thorchain_swap.swap", // Already has function ID
+		Resource: "ripple.thorchain_swap.swap", // Already has function ID
 		Target: &types.Target{
 			TargetType: types.TargetType_TARGET_TYPE_ADDRESS,
 			Target: &types.Target_Address{
@@ -1436,7 +1436,7 @@ func TestTryFormat_XRP_UnsupportedProtocol(t *testing.T) {
 	metaRule := NewMetaRule()
 
 	rule := &types.Rule{
-		Resource: "xrp.stake", // Unsupported protocol
+		Resource: "ripple.stake", // Unsupported protocol
 		ParameterConstraints: []*types.ParameterConstraint{
 			{
 				ParameterName: "recipient",

--- a/resolver/thorchain_vault_test.go
+++ b/resolver/thorchain_vault_test.go
@@ -80,7 +80,7 @@ func TestTHORChainVaultResolver_Resolve_Integration(t *testing.T) {
 		},
 		{
 			name:    "resolve XRP vault address",
-			chainID: "xrp",
+			chainID: "ripple",
 			assetID: "xrp",
 			wantErr: false,
 		},
@@ -206,7 +206,7 @@ func TestTHORChainVaultResolver_APIConsistency(t *testing.T) {
 		{"ethereum", "ETH"},
 		{"bitcoin", "BTC"},
 		{"base", "BASE"},
-		{"xrp", "XRP"},
+		{"ripple", "XRP"},
 	}
 
 	for _, chain := range supportedChains {


### PR DESCRIPTION
Change chain name from xrp to ripple as mentioned in [#169]

Tested with ripple.xrp.send:
https://xrpscan.com/tx/791DBEC9305552578465E68653CA883EEAA33379C4452C885ECE39858DB434CF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized naming from “XRP” to “Ripple” across rule resources and related operations for consistency.
- Tests
  - Updated test cases and expectations to reflect the Ripple naming, ensuring validations and formatting align with the new identifiers.
- Chores
  - Upgraded a core dependency to the latest version for improved alignment with upstream changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->