### PR TITLE
Remove double adding of SigningPubKey in XRP

### DIFF
--- a/sdk/xrpl/xrpl.go
+++ b/sdk/xrpl/xrpl.go
@@ -230,17 +230,17 @@ func (sdk *SDK) Sign(unsignedTxBytes []byte, signatures map[string]tss.KeysignRe
 		return nil, fmt.Errorf("binary-codec decode (unsigned) failed: %w", err)
 	}
 
-	// Ensure base doesn't already contain SigningPubKey/TxnSignature
-	if _, has := m["SigningPubKey"]; has {
-		return nil, fmt.Errorf("base tx already contains SigningPubKey; pass an unsigned base")
-	}
+	// Ensure base doesn't already contain TxnSignature
 	if _, has := m["TxnSignature"]; has {
 		return nil, fmt.Errorf("base tx already contains TxnSignature; pass an unsigned base")
 	}
 
-	// Add SigningPubKey to the transaction map
-	pubHex := strings.ToUpper(hex.EncodeToString(pubKey))
-	m["SigningPubKey"] = pubHex
+	// SigningPubKey should already be present from the build script
+	// If it's not present, add it as a fallback
+	if _, has := m["SigningPubKey"]; !has {
+		pubHex := strings.ToUpper(hex.EncodeToString(pubKey))
+		m["SigningPubKey"] = pubHex
+	}
 
 	// Re-encode with SigningPubKey (but without TxnSignature) to get canonical bytes for signing
 	withPubHex, err := xrpgo.Encode(m)


### PR DESCRIPTION
The xrp tx hex should already have the SigningPubKey before signing, so the XRP SDK should not have to append the SigningPubKey again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Signing now respects an existing public key in a transaction and only adds one if missing.
  - Prevents signing when a transaction already contains a signature, avoiding accidental double-signing.
  - Canonicalization and encoding now handle public-key presence correctly, improving signing reliability.

- **Refactor**
  - Simplified signing flow to avoid unnecessary mutations and better align with standard build processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->