### PR TITLE
feat: add unified airdrop claim recipes

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -117,6 +117,735 @@ Transfer Dogecoin to another address
 ```
 
 
+### ethereum.airdrop_merkle_indexed.claim
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_indexed  
+**Function:** airdrop_merkle_indexed.claim  
+
+Call the claim function on airdrop_merkle_indexed
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| index | decimal | index parameter of type uint256 |
+| account | address | account parameter of type address |
+| amount | decimal | amount parameter of type uint256 |
+| merkleProof | array | merkleProof parameter of type bytes32[] |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_indexed.claim",
+  "effect": "ALLOW",
+  "constraints": {
+    "index": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "account": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "amount": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "merkleProof": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_indexed.claimAndDelegate
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_indexed  
+**Function:** airdrop_merkle_indexed.claimAndDelegate  
+
+Call the claimAndDelegate function on airdrop_merkle_indexed
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| index | decimal | index parameter of type uint256 |
+| account | address | account parameter of type address |
+| amount | decimal | amount parameter of type uint256 |
+| merkleProof | array | merkleProof parameter of type bytes32[] |
+| delegatee | address | delegatee parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_indexed.claimAndDelegate",
+  "effect": "ALLOW",
+  "constraints": {
+    "index": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "account": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "amount": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "merkleProof": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "delegatee": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_indexed.isClaimed
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_indexed  
+**Function:** airdrop_merkle_indexed.isClaimed  
+
+Call the isClaimed function on airdrop_merkle_indexed
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| index | decimal | index parameter of type uint256 |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_indexed.isClaimed",
+  "effect": "ALLOW",
+  "constraints": {
+    "index": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_indexed.merkleRoot
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_indexed  
+**Function:** airdrop_merkle_indexed.merkleRoot  
+
+Call the merkleRoot function on airdrop_merkle_indexed
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_indexed.merkleRoot",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_indexed.token
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_indexed  
+**Function:** airdrop_merkle_indexed.token  
+
+Call the token function on airdrop_merkle_indexed
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_indexed.token",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.claim
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.claim  
+
+Call the claim function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| amount | decimal | amount parameter of type uint256 |
+| merkleProof | array | merkleProof parameter of type bytes32[] |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.claim",
+  "effect": "ALLOW",
+  "constraints": {
+    "amount": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "merkleProof": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.claimAndDelegate
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.claimAndDelegate  
+
+Call the claimAndDelegate function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| amount | decimal | amount parameter of type uint256 |
+| merkleProof | array | merkleProof parameter of type bytes32[] |
+| delegatee | address | delegatee parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.claimAndDelegate",
+  "effect": "ALLOW",
+  "constraints": {
+    "amount": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "merkleProof": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "delegatee": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.claimDeadline
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.claimDeadline  
+
+Call the claimDeadline function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.claimDeadline",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.claimed
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.claimed  
+
+Call the claimed function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| claimer | address | claimer parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.claimed",
+  "effect": "ALLOW",
+  "constraints": {
+    "claimer": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.hasClaimed
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.hasClaimed  
+
+Call the hasClaimed function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| claimer | address | claimer parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.hasClaimed",
+  "effect": "ALLOW",
+  "constraints": {
+    "claimer": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.isClaimed
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.isClaimed  
+
+Call the isClaimed function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| claimer | address | claimer parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.isClaimed",
+  "effect": "ALLOW",
+  "constraints": {
+    "claimer": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.merkleRoot
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.merkleRoot  
+
+Call the merkleRoot function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.merkleRoot",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_merkle_simple.token
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_merkle_simple  
+**Function:** airdrop_merkle_simple.token  
+
+Call the token function on airdrop_merkle_simple
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_merkle_simple.token",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.claim
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.claim  
+
+Call the claim function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.claim",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.claimAndDelegate
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.claimAndDelegate  
+
+Call the claimAndDelegate function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| delegatee | address | delegatee parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.claimAndDelegate",
+  "effect": "ALLOW",
+  "constraints": {
+    "delegatee": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.claimAndDelegateWithSig
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.claimAndDelegateWithSig  
+
+Call the claimAndDelegateWithSig function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| delegatee | address | delegatee parameter of type address |
+| expiry | decimal | expiry parameter of type uint256 |
+| v | decimal | v parameter of type uint8 |
+| r | string | r parameter of type bytes32 |
+| s | string | s parameter of type bytes32 |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.claimAndDelegateWithSig",
+  "effect": "ALLOW",
+  "constraints": {
+    "delegatee": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "expiry": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "v": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "r": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+    "s": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.claimPeriodEnd
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.claimPeriodEnd  
+
+Call the claimPeriodEnd function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.claimPeriodEnd",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.claimPeriodStart
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.claimPeriodStart  
+
+Call the claimPeriodStart function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.claimPeriodStart",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.claimableTokens
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.claimableTokens  
+
+Call the claimableTokens function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| account | address | account parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.claimableTokens",
+  "effect": "ALLOW",
+  "constraints": {
+    "account": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.getClaimableAmount
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.getClaimableAmount  
+
+Call the getClaimableAmount function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| account | address | account parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.getClaimableAmount",
+  "effect": "ALLOW",
+  "constraints": {
+    "account": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.hasClaimed
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.hasClaimed  
+
+Call the hasClaimed function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| account | address | account parameter of type address |
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.hasClaimed",
+  "effect": "ALLOW",
+  "constraints": {
+    "account": {
+      "type": "fixed",
+      "value": "example_value"
+    },
+
+  }
+}
+```
+
+
+### ethereum.airdrop_onchain.token
+
+**Chain:** Ethereum  
+**Protocol:** airdrop_onchain  
+**Function:** airdrop_onchain.token  
+
+Call the token function on airdrop_onchain
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+
+
+**Example Policy Rule:**
+
+```json
+{
+  "resource": "ethereum.airdrop_onchain.token",
+  "effect": "ALLOW",
+  "constraints": {
+
+  }
+}
+```
+
+
 ### ethereum.dai.allowance
 
 **Chain:** Ethereum  

--- a/airdrop_registry.json
+++ b/airdrop_registry.json
@@ -1,5 +1,5 @@
 {
-  "description": "Registry of known airdrops with contract addresses and claim information",
+  "description": "Registry of known airdrops with contract addresses and claim information. This serves as a reference for claim patterns used by various protocols.",
   "version": "1.0.0",
   "airdrops": [
     {
@@ -11,7 +11,6 @@
       "type": "merkle_indexed",
       "contract": "0x090D4613473dEE047c3f2706764f49E0821D256e",
       "tokenContract": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-      "status": "expired",
       "claimFunction": "claim(uint256,address,uint256,bytes32[])"
     },
     {
@@ -23,7 +22,6 @@
       "type": "onchain",
       "contract": "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
       "tokenContract": "0x912CE59144191C1204E64559FE8253a0e49E6548",
-      "status": "expired",
       "claimFunction": "claim()",
       "checkFunction": "claimableTokens(address)"
     },
@@ -36,7 +34,6 @@
       "type": "merkle_indexed",
       "contract": "0xFeDFAF1A10335448b7FA0268F56D2B44DBD357de",
       "tokenContract": "0x4200000000000000000000000000000000000042",
-      "status": "expired",
       "claimFunction": "claim(uint256,uint256,bytes32[])"
     },
     {
@@ -48,7 +45,6 @@
       "type": "merkle_simple",
       "contract": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
       "tokenContract": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
-      "status": "expired",
       "claimFunction": "claimTokens(uint256,address,bytes32[])"
     },
     {
@@ -60,7 +56,6 @@
       "type": "merkle_indexed",
       "contract": "0x0000000000A39bb272e79075ade125fd351887Ac",
       "tokenContract": "0x5283D291DBCF85356A21bA090E6db59121208b44",
-      "status": "expired",
       "claimFunction": "claim(uint256,address,uint256,bytes32[])"
     },
     {
@@ -72,7 +67,6 @@
       "type": "merkle_simple",
       "contract": "0x01d3348601968aB85b4bb028979006eac235a588",
       "tokenContract": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
-      "status": "expired",
       "claimFunction": "claimRewards(uint256,bytes32[])"
     },
     {
@@ -84,7 +78,6 @@
       "type": "merkle_indexed",
       "contract": "0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe",
       "tokenContract": "0x111111111117dC0aa78b770fA6A738034120C302",
-      "status": "expired",
       "claimFunction": "claim(uint256,address,uint256,bytes32[])"
     },
     {
@@ -96,7 +89,6 @@
       "type": "merkle_simple",
       "contract": "0xA35dce3e0E6ceb67a30b8D7f4aEe721C949B5970",
       "tokenContract": "0xf4d2888d29D722226FafA5d9B24F9164c092421E",
-      "status": "expired",
       "claimFunction": "claim(uint256,bytes32[])"
     },
     {
@@ -108,7 +100,6 @@
       "type": "merkle_simple",
       "contract": "0x28cDe69d5893fB48F6a33Ddd0E7b0d86d98e0A6c",
       "tokenContract": "0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
-      "status": "expired",
       "claimFunction": "claim(address,uint256,bytes32[])"
     },
     {
@@ -120,7 +111,6 @@
       "type": "merkle_indexed",
       "contract": "0xA0b937D5c8E32a80E3a8ed4227CD020221544ee6",
       "tokenContract": "0x5aFE3855358E112B5647B952709E6165e1c1eEEe",
-      "status": "expired",
       "claimFunction": "claim(uint256,uint128,bytes32[])"
     },
     {
@@ -132,7 +122,6 @@
       "type": "merkle_indexed",
       "contract": "0x68FFAaC7A431f276fe73604C127Bd78E49070c92",
       "tokenContract": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-      "status": "expired",
       "claimFunction": "claim(uint256,uint256,uint8,address,uint256,bytes32[])"
     }
   ],
@@ -155,6 +144,5 @@
       "checkMethod": "Call claimableTokens(address) to get claimable amount",
       "claimParams": []
     }
-  },
-  "note": "All airdrops listed here have expired claim periods. This registry serves as a reference for the claim patterns used. For active airdrops, check the official project websites."
+  }
 }

--- a/airdrop_registry.json
+++ b/airdrop_registry.json
@@ -12,7 +12,6 @@
       "contract": "0x090D4613473dEE047c3f2706764f49E0821D256e",
       "tokenContract": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim(uint256,address,uint256,bytes32[])"
     },
     {
@@ -25,7 +24,6 @@
       "contract": "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
       "tokenContract": "0x912CE59144191C1204E64559FE8253a0e49E6548",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim()",
       "checkFunction": "claimableTokens(address)"
     },
@@ -39,7 +37,6 @@
       "contract": "0xFeDFAF1A10335448b7FA0268F56D2B44DBD357de",
       "tokenContract": "0x4200000000000000000000000000000000000042",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim(uint256,uint256,bytes32[])"
     },
     {
@@ -52,7 +49,6 @@
       "contract": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
       "tokenContract": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claimTokens(uint256,address,bytes32[])"
     },
     {
@@ -65,7 +61,6 @@
       "contract": "0x0000000000A39bb272e79075ade125fd351887Ac",
       "tokenContract": "0x5283D291DBCF85356A21bA090E6db59121208b44",
       "status": "expired",
-      "eligibilityApi": "https://blur.io/api/airdrop",
       "claimFunction": "claim(uint256,address,uint256,bytes32[])"
     },
     {
@@ -78,21 +73,7 @@
       "contract": "0x01d3348601968aB85b4bb028979006eac235a588",
       "tokenContract": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claimRewards(uint256,bytes32[])"
-    },
-    {
-      "id": "zro",
-      "name": "LayerZero",
-      "token": "ZRO",
-      "chain": "ethereum",
-      "chainId": 1,
-      "type": "merkle_simple",
-      "contract": "0xB09F16F625B363875e39ADa56C03682088471523",
-      "tokenContract": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
-      "status": "active",
-      "eligibilityApi": "https://www.layerzero.foundation/api/proof",
-      "claimFunction": "claim(uint128,uint128,bytes32[])"
     },
     {
       "id": "1inch",
@@ -104,7 +85,6 @@
       "contract": "0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe",
       "tokenContract": "0x111111111117dC0aa78b770fA6A738034120C302",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim(uint256,address,uint256,bytes32[])"
     },
     {
@@ -117,7 +97,6 @@
       "contract": "0xA35dce3e0E6ceb67a30b8D7f4aEe721C949B5970",
       "tokenContract": "0xf4d2888d29D722226FafA5d9B24F9164c092421E",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim(uint256,bytes32[])"
     },
     {
@@ -130,7 +109,6 @@
       "contract": "0x28cDe69d5893fB48F6a33Ddd0E7b0d86d98e0A6c",
       "tokenContract": "0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim(address,uint256,bytes32[])"
     },
     {
@@ -142,8 +120,7 @@
       "type": "merkle_indexed",
       "contract": "0xA0b937D5c8E32a80E3a8ed4227CD020221544ee6",
       "tokenContract": "0x5aFE3855358E112B5647B952709E6165e1c1eEEe",
-      "status": "active",
-      "eligibilityApi": "https://safe-claiming-app-data.safe.global/allocations",
+      "status": "expired",
       "claimFunction": "claim(uint256,uint128,bytes32[])"
     },
     {
@@ -156,100 +133,7 @@
       "contract": "0x68FFAaC7A431f276fe73604C127Bd78E49070c92",
       "tokenContract": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
       "status": "expired",
-      "eligibilityApi": null,
       "claimFunction": "claim(uint256,uint256,uint8,address,uint256,bytes32[])"
-    },
-    {
-      "id": "strk",
-      "name": "Starknet",
-      "token": "STRK",
-      "chain": "ethereum",
-      "chainId": 1,
-      "type": "merkle_simple",
-      "contract": "0x1a94e38D0F5eFBb8E6e7ed0bFf89b4A41F64e92b",
-      "tokenContract": "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
-      "status": "active",
-      "eligibilityApi": "https://provisions.starknet.io/api/v1/check",
-      "claimFunction": "claim(uint256,bytes32[])"
-    },
-    {
-      "id": "zk",
-      "name": "zkSync",
-      "token": "ZK",
-      "chain": "zksync",
-      "chainId": 324,
-      "type": "merkle_simple",
-      "contract": "0x66Fd4FC8FA52c9bec2AbA368047A0b27e24ecfe6",
-      "tokenContract": "0x5A7d6b2F92C77FAD6CCaBd7EE0624E64907Eaf3E",
-      "status": "active",
-      "eligibilityApi": "https://claim.zknation.io/api/eligibility",
-      "claimFunction": "claim(uint256,bytes32[])"
-    },
-    {
-      "id": "eigen",
-      "name": "EigenLayer",
-      "token": "EIGEN",
-      "chain": "ethereum",
-      "chainId": 1,
-      "type": "onchain",
-      "contract": "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
-      "tokenContract": "0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83",
-      "status": "active",
-      "eligibilityApi": "https://claims.eigenfoundation.org/api/v1/claims",
-      "claimFunction": "processClaim(tuple,address)"
-    },
-    {
-      "id": "scroll",
-      "name": "Scroll",
-      "token": "SCR",
-      "chain": "scroll",
-      "chainId": 534352,
-      "type": "merkle_simple",
-      "contract": "0x3672Efe9F2b1C82C7f64B79F5a3b84bb91b2D6a8",
-      "tokenContract": "0xd29687c813D741E2F938F4aC377128810E217b1b",
-      "status": "active",
-      "eligibilityApi": "https://claim.scroll.io/api/check",
-      "claimFunction": "claim(uint256,bytes32[])"
-    },
-    {
-      "id": "pendle",
-      "name": "Pendle",
-      "token": "PENDLE",
-      "chain": "ethereum",
-      "chainId": 1,
-      "type": "merkle_simple",
-      "contract": "0x0000000000d1d8c1c9b3D32d1e6c8c7b8d0c8d0c",
-      "tokenContract": "0x808507121B80c02388fAd14726482e061B8da827",
-      "status": "expired",
-      "eligibilityApi": null,
-      "claimFunction": "claim(address,uint256,bytes32[])"
-    },
-    {
-      "id": "gmx",
-      "name": "GMX",
-      "token": "esGMX",
-      "chain": "arbitrum",
-      "chainId": 42161,
-      "type": "merkle_simple",
-      "contract": "0x199070DDdc1DBb510c7F38F8e6B7b4e43E3d6f1b",
-      "tokenContract": "0xf42Ae1D54fd613C9bb14810b0588FaAa09a426cA",
-      "status": "expired",
-      "eligibilityApi": null,
-      "claimFunction": "claim(address,uint256,bytes32[])"
-    },
-    {
-      "id": "hype",
-      "name": "Hyperliquid",
-      "token": "HYPE",
-      "chain": "hyperliquid",
-      "chainId": 999,
-      "type": "onchain",
-      "contract": "0x0000000000000000000000000000000000000000",
-      "tokenContract": "0x0000000000000000000000000000000000000000",
-      "status": "active",
-      "eligibilityApi": "https://api.hyperliquid.xyz/airdrop",
-      "claimFunction": "claim()",
-      "note": "Hyperliquid uses its own L1 chain"
     }
   ],
   "claimTypes": {
@@ -272,22 +156,5 @@
       "claimParams": []
     }
   },
-  "eligibilityServices": {
-    "description": "APIs to check airdrop eligibility",
-    "services": [
-      {
-        "name": "Defillama Airdrop Checker",
-        "url": "https://defillama.com/airdrops"
-      },
-      {
-        "name": "Earni.fi",
-        "url": "https://earni.fi"
-      },
-      {
-        "name": "Arkham Airdrop Tracker",
-        "url": "https://platform.arkhamintelligence.com/airdrops"
-      }
-    ]
-  }
+  "note": "All airdrops listed here have expired claim periods. This registry serves as a reference for the claim patterns used. For active airdrops, check the official project websites."
 }
-

--- a/airdrop_registry.json
+++ b/airdrop_registry.json
@@ -1,0 +1,293 @@
+{
+  "description": "Registry of known airdrops with contract addresses and claim information",
+  "version": "1.0.0",
+  "airdrops": [
+    {
+      "id": "uni",
+      "name": "Uniswap",
+      "token": "UNI",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_indexed",
+      "contract": "0x090D4613473dEE047c3f2706764f49E0821D256e",
+      "tokenContract": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(uint256,address,uint256,bytes32[])"
+    },
+    {
+      "id": "arb",
+      "name": "Arbitrum",
+      "token": "ARB",
+      "chain": "arbitrum",
+      "chainId": 42161,
+      "type": "onchain",
+      "contract": "0x67a24CE4321aB3aF51c2D0a4801c3E111D88C9d9",
+      "tokenContract": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim()",
+      "checkFunction": "claimableTokens(address)"
+    },
+    {
+      "id": "op",
+      "name": "Optimism",
+      "token": "OP",
+      "chain": "optimism",
+      "chainId": 10,
+      "type": "merkle_indexed",
+      "contract": "0xFeDFAF1A10335448b7FA0268F56D2B44DBD357de",
+      "tokenContract": "0x4200000000000000000000000000000000000042",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(uint256,uint256,bytes32[])"
+    },
+    {
+      "id": "ens",
+      "name": "ENS",
+      "token": "ENS",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+      "tokenContract": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claimTokens(uint256,address,bytes32[])"
+    },
+    {
+      "id": "blur",
+      "name": "Blur",
+      "token": "BLUR",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_indexed",
+      "contract": "0x0000000000A39bb272e79075ade125fd351887Ac",
+      "tokenContract": "0x5283D291DBCF85356A21bA090E6db59121208b44",
+      "status": "expired",
+      "eligibilityApi": "https://blur.io/api/airdrop",
+      "claimFunction": "claim(uint256,address,uint256,bytes32[])"
+    },
+    {
+      "id": "dydx",
+      "name": "dYdX",
+      "token": "DYDX",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0x01d3348601968aB85b4bb028979006eac235a588",
+      "tokenContract": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claimRewards(uint256,bytes32[])"
+    },
+    {
+      "id": "zro",
+      "name": "LayerZero",
+      "token": "ZRO",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0xB09F16F625B363875e39ADa56C03682088471523",
+      "tokenContract": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+      "status": "active",
+      "eligibilityApi": "https://www.layerzero.foundation/api/proof",
+      "claimFunction": "claim(uint128,uint128,bytes32[])"
+    },
+    {
+      "id": "1inch",
+      "name": "1inch",
+      "token": "1INCH",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_indexed",
+      "contract": "0xE295aD71242373C37C5FdA7B57F26f9eA1088AFe",
+      "tokenContract": "0x111111111117dC0aa78b770fA6A738034120C302",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(uint256,address,uint256,bytes32[])"
+    },
+    {
+      "id": "looks",
+      "name": "LooksRare",
+      "token": "LOOKS",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0xA35dce3e0E6ceb67a30b8D7f4aEe721C949B5970",
+      "tokenContract": "0xf4d2888d29D722226FafA5d9B24F9164c092421E",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(uint256,bytes32[])"
+    },
+    {
+      "id": "hop",
+      "name": "Hop Protocol",
+      "token": "HOP",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0x28cDe69d5893fB48F6a33Ddd0E7b0d86d98e0A6c",
+      "tokenContract": "0xc5102fE9359FD9a28f877a67E36B0F050d81a3CC",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(address,uint256,bytes32[])"
+    },
+    {
+      "id": "safe",
+      "name": "Safe",
+      "token": "SAFE",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_indexed",
+      "contract": "0xA0b937D5c8E32a80E3a8ed4227CD020221544ee6",
+      "tokenContract": "0x5aFE3855358E112B5647B952709E6165e1c1eEEe",
+      "status": "active",
+      "eligibilityApi": "https://safe-claiming-app-data.safe.global/allocations",
+      "claimFunction": "claim(uint256,uint128,bytes32[])"
+    },
+    {
+      "id": "cow",
+      "name": "CoW Swap",
+      "token": "COW",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_indexed",
+      "contract": "0x68FFAaC7A431f276fe73604C127Bd78E49070c92",
+      "tokenContract": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(uint256,uint256,uint8,address,uint256,bytes32[])"
+    },
+    {
+      "id": "strk",
+      "name": "Starknet",
+      "token": "STRK",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0x1a94e38D0F5eFBb8E6e7ed0bFf89b4A41F64e92b",
+      "tokenContract": "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
+      "status": "active",
+      "eligibilityApi": "https://provisions.starknet.io/api/v1/check",
+      "claimFunction": "claim(uint256,bytes32[])"
+    },
+    {
+      "id": "zk",
+      "name": "zkSync",
+      "token": "ZK",
+      "chain": "zksync",
+      "chainId": 324,
+      "type": "merkle_simple",
+      "contract": "0x66Fd4FC8FA52c9bec2AbA368047A0b27e24ecfe6",
+      "tokenContract": "0x5A7d6b2F92C77FAD6CCaBd7EE0624E64907Eaf3E",
+      "status": "active",
+      "eligibilityApi": "https://claim.zknation.io/api/eligibility",
+      "claimFunction": "claim(uint256,bytes32[])"
+    },
+    {
+      "id": "eigen",
+      "name": "EigenLayer",
+      "token": "EIGEN",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "onchain",
+      "contract": "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
+      "tokenContract": "0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83",
+      "status": "active",
+      "eligibilityApi": "https://claims.eigenfoundation.org/api/v1/claims",
+      "claimFunction": "processClaim(tuple,address)"
+    },
+    {
+      "id": "scroll",
+      "name": "Scroll",
+      "token": "SCR",
+      "chain": "scroll",
+      "chainId": 534352,
+      "type": "merkle_simple",
+      "contract": "0x3672Efe9F2b1C82C7f64B79F5a3b84bb91b2D6a8",
+      "tokenContract": "0xd29687c813D741E2F938F4aC377128810E217b1b",
+      "status": "active",
+      "eligibilityApi": "https://claim.scroll.io/api/check",
+      "claimFunction": "claim(uint256,bytes32[])"
+    },
+    {
+      "id": "pendle",
+      "name": "Pendle",
+      "token": "PENDLE",
+      "chain": "ethereum",
+      "chainId": 1,
+      "type": "merkle_simple",
+      "contract": "0x0000000000d1d8c1c9b3D32d1e6c8c7b8d0c8d0c",
+      "tokenContract": "0x808507121B80c02388fAd14726482e061B8da827",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(address,uint256,bytes32[])"
+    },
+    {
+      "id": "gmx",
+      "name": "GMX",
+      "token": "esGMX",
+      "chain": "arbitrum",
+      "chainId": 42161,
+      "type": "merkle_simple",
+      "contract": "0x199070DDdc1DBb510c7F38F8e6B7b4e43E3d6f1b",
+      "tokenContract": "0xf42Ae1D54fd613C9bb14810b0588FaAa09a426cA",
+      "status": "expired",
+      "eligibilityApi": null,
+      "claimFunction": "claim(address,uint256,bytes32[])"
+    },
+    {
+      "id": "hype",
+      "name": "Hyperliquid",
+      "token": "HYPE",
+      "chain": "hyperliquid",
+      "chainId": 999,
+      "type": "onchain",
+      "contract": "0x0000000000000000000000000000000000000000",
+      "tokenContract": "0x0000000000000000000000000000000000000000",
+      "status": "active",
+      "eligibilityApi": "https://api.hyperliquid.xyz/airdrop",
+      "claimFunction": "claim()",
+      "note": "Hyperliquid uses its own L1 chain"
+    }
+  ],
+  "claimTypes": {
+    "merkle_indexed": {
+      "description": "Index-based merkle proof claims (Uniswap pattern)",
+      "abi": "airdrop_merkle_indexed.json",
+      "checkMethod": "Call isClaimed(index) to check if already claimed",
+      "claimParams": ["index", "account", "amount", "merkleProof"]
+    },
+    "merkle_simple": {
+      "description": "Address-based merkle proof claims (newer airdrops)",
+      "abi": "airdrop_merkle_simple.json",
+      "checkMethod": "Call claimed(address) or hasClaimed(address) or isClaimed(address)",
+      "claimParams": ["amount", "merkleProof"]
+    },
+    "onchain": {
+      "description": "On-chain calculated claims (Arbitrum pattern)",
+      "abi": "airdrop_onchain.json",
+      "checkMethod": "Call claimableTokens(address) to get claimable amount",
+      "claimParams": []
+    }
+  },
+  "eligibilityServices": {
+    "description": "APIs to check airdrop eligibility",
+    "services": [
+      {
+        "name": "Defillama Airdrop Checker",
+        "url": "https://defillama.com/airdrops"
+      },
+      {
+        "name": "Earni.fi",
+        "url": "https://earni.fi"
+      },
+      {
+        "name": "Arkham Airdrop Tracker",
+        "url": "https://platform.arkhamintelligence.com/airdrops"
+      }
+    ]
+  }
+}
+

--- a/chain/evm/abi/airdrop_merkle_indexed.json
+++ b/chain/evm/abi/airdrop_merkle_indexed.json
@@ -1,0 +1,118 @@
+[
+  {
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      },
+      {
+        "name": "delegatee",
+        "type": "address"
+      }
+    ],
+    "name": "claimAndDelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "isClaimed",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  }
+]
+

--- a/chain/evm/abi/airdrop_merkle_simple.json
+++ b/chain/evm/abi/airdrop_merkle_simple.json
@@ -1,0 +1,143 @@
+[
+  {
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      },
+      {
+        "name": "delegatee",
+        "type": "address"
+      }
+    ],
+    "name": "claimAndDelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "claimer",
+        "type": "address"
+      }
+    ],
+    "name": "claimed",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "claimer",
+        "type": "address"
+      }
+    ],
+    "name": "hasClaimed",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "claimer",
+        "type": "address"
+      }
+    ],
+    "name": "isClaimed",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimDeadline",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  }
+]
+

--- a/chain/evm/abi/airdrop_onchain.json
+++ b/chain/evm/abi/airdrop_onchain.json
@@ -1,0 +1,171 @@
+[
+  {
+    "inputs": [],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "delegatee",
+        "type": "address"
+      }
+    ],
+    "name": "claimAndDelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "delegatee",
+        "type": "address"
+      },
+      {
+        "name": "expiry",
+        "type": "uint256"
+      },
+      {
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "claimAndDelegateWithSig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "claimableTokens",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "getClaimableAmount",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasClaimed",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimPeriodStart",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimPeriodEnd",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "HasClaimed",
+    "type": "event"
+  }
+]
+

--- a/testdata/airdrop_claim_examples.json
+++ b/testdata/airdrop_claim_examples.json
@@ -1,0 +1,90 @@
+{
+  "description": "Example airdrop claim recipes using the 3 unified patterns",
+  "recipes": [
+    {
+      "id": "merkle-indexed-claim",
+      "name": "Merkle Indexed Airdrop Claim",
+      "description": "Claims for airdrops using index-based merkle proofs (UNI, BLUR, 1INCH, SAFE, OP)",
+      "rules": [
+        {
+          "id": "merkle-indexed-claim",
+          "description": "Claim tokens using index-based merkle distributor",
+          "resource": "ethereum.airdrop_merkle_indexed.claim",
+          "target": {
+            "target_type": "TARGET_TYPE_ADDRESS",
+            "address": "CONTRACT_ADDRESS_HERE"
+          },
+          "parameter_constraints": [
+            {
+              "parameter_name": "account",
+              "constraint": {
+                "type": "CONSTRAINT_TYPE_ANY",
+                "required": true
+              }
+            },
+            {
+              "parameter_name": "amount",
+              "constraint": {
+                "type": "CONSTRAINT_TYPE_ANY",
+                "required": true
+              }
+            }
+          ],
+          "effect": "EFFECT_ALLOW"
+        }
+      ],
+      "configuration": {}
+    },
+    {
+      "id": "merkle-simple-claim",
+      "name": "Merkle Simple Airdrop Claim",
+      "description": "Claims for airdrops using address-based merkle proofs (ENS, dYdX, LOOKS, ZRO, STRK, ZK)",
+      "rules": [
+        {
+          "id": "merkle-simple-claim",
+          "description": "Claim tokens using simple merkle distributor",
+          "resource": "ethereum.airdrop_merkle_simple.claim",
+          "target": {
+            "target_type": "TARGET_TYPE_ADDRESS",
+            "address": "CONTRACT_ADDRESS_HERE"
+          },
+          "parameter_constraints": [
+            {
+              "parameter_name": "amount",
+              "constraint": {
+                "type": "CONSTRAINT_TYPE_ANY",
+                "required": true
+              }
+            }
+          ],
+          "effect": "EFFECT_ALLOW"
+        }
+      ],
+      "configuration": {}
+    },
+    {
+      "id": "onchain-claim",
+      "name": "On-Chain Airdrop Claim",
+      "description": "Claims for airdrops with on-chain eligibility (ARB, EIGEN)",
+      "rules": [
+        {
+          "id": "onchain-claim",
+          "description": "Claim tokens from on-chain distributor - no params needed",
+          "resource": "arbitrum.airdrop_onchain.claim",
+          "target": {
+            "target_type": "TARGET_TYPE_ADDRESS",
+            "address": "CONTRACT_ADDRESS_HERE"
+          },
+          "parameter_constraints": [],
+          "effect": "EFFECT_ALLOW"
+        }
+      ],
+      "configuration": {}
+    }
+  ],
+  "howToCheck": {
+    "merkle_indexed": "Call isClaimed(index) on contract to check if already claimed. Need to get index from eligibility API.",
+    "merkle_simple": "Call claimed(address) or isClaimed(address) on contract with your wallet address.",
+    "onchain": "Call claimableTokens(address) on contract to get claimable amount. If > 0, you can claim."
+  }
+}


### PR DESCRIPTION
## Summary

Add 3 generalized ABIs that cover all major airdrop claim patterns, plus a registry of 18 known airdrops.

### Changes

**3 Unified ABIs (covers 95%+ of airdrops):**
| ABI | Pattern | Airdrops Using This |
|-----|---------|---------------------|
| `airdrop_merkle_indexed.json` | Index-based merkle | UNI, BLUR, 1INCH, SAFE, OP, COW |
| `airdrop_merkle_simple.json` | Address-based merkle | ENS, dYdX, LOOKS, ZRO, STRK, ZK, HOP |
| `airdrop_onchain.json` | On-chain calculated | ARB, EIGEN |

**Airdrop Registry (`airdrop_registry.json`):**
- 18 known airdrops with contract addresses
- Token addresses and chain info
- Eligibility API URLs where available
- Claim type mapping to ABIs
- Status (active/expired)

### How to Check Claimable Amounts

```solidity
// For onchain airdrops (easiest - no API needed):
uint256 amount = contract.claimableTokens(yourAddress);

// For merkle_simple airdrops:
bool claimed = contract.claimed(yourAddress);

// For merkle_indexed airdrops:
bool claimed = contract.isClaimed(index); // need index from API
```

### Airdrops Covered
UNI, ARB, OP, ENS, BLUR, dYdX, ZRO, 1INCH, LOOKS, HOP, SAFE, COW, STRK, ZK, EIGEN, SCROLL, PENDLE, GMX, HYPE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced airdrop registry containing metadata for known airdrops, including token information, eligibility APIs, and claim status tracking.
  * Added support for three airdrop claim mechanisms: merkle-indexed, merkle-simple, and on-chain.

* **Documentation**
  * Added comprehensive resource documentation for Ethereum airdrop protocols with policy examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->