### PR TITLE
Support Memo validation for ripple.send

### DIFF
--- a/chain/xrpl/chain.go
+++ b/chain/xrpl/chain.go
@@ -112,13 +112,13 @@ func (p *ParsedXRPLTransaction) GetMemo() (string, error) {
 // ExtractMemoFromXRPPayment extracts memo data from XRPL Payment transaction.
 func ExtractMemoFromXRPPayment(payment *transactions.Payment) (string, error) {
 	if len(payment.Memos) == 0 {
-		return "", fmt.Errorf("no memo found in payment transaction")
+		return "", fmt.Errorf("memo required but not found in payment transaction")
 	}
 
 	// XRPL memos are typically hex-encoded, need to decode
 	memo := payment.Memos[0]
 	if memo.Memo.MemoData == "" {
-		return "", fmt.Errorf("empty memo data")
+		return "", fmt.Errorf("memo field present but empty")
 	}
 
 	// Decode hex to string (THORChain memos are text)

--- a/metarule/metarule_test.go
+++ b/metarule/metarule_test.go
@@ -3956,3 +3956,130 @@ func TestTryFormat_Zcash_NonMetaRule(t *testing.T) {
 	require.Len(t, result, 1)
 	assert.Equal(t, rule, result[0]) // Should return unchanged
 }
+
+func TestXRPSend_WithoutMemo(t *testing.T) {
+	metaRule := NewMetaRule()
+
+	rule := &types.Rule{
+		Resource: "ripple.send",
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "asset",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "",
+					},
+				},
+			},
+			{
+				ParameterName: "to_address",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "rDNhvtTNPjjUfvsTD1dFGcXxRvGHfWZm4z",
+					},
+				},
+			},
+			{
+				ParameterName: "amount",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "1000000",
+					},
+				},
+			},
+			{
+				ParameterName: "from_address",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := metaRule.TryFormat(rule)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	assert.Equal(t, "ripple.xrp.transfer", result[0].Resource)
+	assert.Equal(t, types.TargetType_TARGET_TYPE_UNSPECIFIED, result[0].Target.TargetType)
+	require.Len(t, result[0].ParameterConstraints, 2)
+
+	// Verify parameters
+	assert.Equal(t, "recipient", result[0].ParameterConstraints[0].ParameterName)
+	assert.Equal(t, "amount", result[0].ParameterConstraints[1].ParameterName)
+}
+
+func TestXRPSend_WithFixedMemo(t *testing.T) {
+	metaRule := NewMetaRule()
+
+	rule := &types.Rule{
+		Resource: "ripple.send",
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "asset",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "",
+					},
+				},
+			},
+			{
+				ParameterName: "to_address",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "rDNhvtTNPjjUfvsTD1dFGcXxRvGHfWZm4z",
+					},
+				},
+			},
+			{
+				ParameterName: "amount",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "1000000",
+					},
+				},
+			},
+			{
+				ParameterName: "from_address",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+					},
+				},
+			},
+			{
+				ParameterName: "memo",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: "12345678",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := metaRule.TryFormat(rule)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	assert.Equal(t, "ripple.xrp.transfer", result[0].Resource)
+	assert.Equal(t, types.TargetType_TARGET_TYPE_UNSPECIFIED, result[0].Target.TargetType)
+	require.Len(t, result[0].ParameterConstraints, 3)
+
+	// Verify parameters
+	assert.Equal(t, "recipient", result[0].ParameterConstraints[0].ParameterName)
+	assert.Equal(t, "amount", result[0].ParameterConstraints[1].ParameterName)
+	assert.Equal(t, "memo", result[0].ParameterConstraints[2].ParameterName)
+	assert.Equal(t, "12345678", result[0].ParameterConstraints[2].Constraint.GetFixedValue())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * XRP transfers now support optional memo constraints, enabling rules to enforce or validate transaction memo requirements.

* **Bug Fixes**
  * Improved memo validation error messages to provide clearer feedback when memos are missing or invalid.

* **Tests**
  * Added comprehensive test cases for memo constraint validation, covering both successful transactions with valid memos and failures with mismatched memos.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->