### PR TITLE
ZEC: Bug fixes in Recipes

### DIFF
--- a/engine/utxo/zcash/zcash.go
+++ b/engine/utxo/zcash/zcash.go
@@ -28,8 +28,8 @@ func (z *Zcash) Evaluate(rule *types.Rule, txBytes []byte) error {
 	if rule.GetEffect().String() != types.Effect_EFFECT_ALLOW.String() {
 		return fmt.Errorf("only allow rules supported, got: %s", rule.GetEffect().String())
 	}
-	if rule.GetTarget() != nil {
-		return fmt.Errorf("target must be nil for Zcash, got: %s", rule.GetTarget().String())
+	if rule.GetTarget().GetTargetType() != types.TargetType_TARGET_TYPE_UNSPECIFIED {
+		return fmt.Errorf("target type must be unspecified for Zcash, got: %s", rule.GetTarget().GetTargetType().String())
 	}
 
 	tx, err := z.parseTx(txBytes)

--- a/engine/utxo/zcash/zcash_test.go
+++ b/engine/utxo/zcash/zcash_test.go
@@ -532,7 +532,7 @@ func TestZcash_Evaluate_WithTarget_ShouldFail(t *testing.T) {
 		},
 	}, txBytes)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "target must be nil for Zcash")
+	assert.Contains(t, err.Error(), "target type must be unspecified for Zcash")
 }
 
 // Test a MayaChain swap transaction structure:

--- a/metarule/metarule.go
+++ b/metarule/metarule.go
@@ -1175,22 +1175,23 @@ func (m *MetaRule) handleZcash(in *types.Rule, r *types.ResourcePath) ([]*types.
 			return nil, fmt.Errorf("failed to parse chain id: %w", err)
 		}
 
-		thorAsset, err := thorchain.MakeAsset(chainInt, c.toAsset.GetFixedValue())
+		// Zcash swaps use MayaChain, not THORChain
+		mayaAsset, err := mayachain.MakeAsset(chainInt, c.toAsset.GetFixedValue())
 		if err != nil {
-			return nil, fmt.Errorf("failed to make thor asset: %w", err)
+			return nil, fmt.Errorf("failed to make maya asset: %w", err)
 		}
 
 		// Create asset pattern that accepts both full form and shortform
-		shortCode := thorchain.ShortCode(thorAsset)
+		shortCode := mayachain.ShortCode(mayaAsset)
 		var assetPattern string
 		if shortCode != "" {
 			// Accept both full form and shortform: (ZEC\.ZEC|z)
 			assetPattern = fmt.Sprintf("(%s|%s)",
-				regexp.QuoteMeta(thorAsset),
+				regexp.QuoteMeta(mayaAsset),
 				regexp.QuoteMeta(shortCode))
 		} else {
 			// Fallback to full asset name only
-			assetPattern = regexp.QuoteMeta(thorAsset)
+			assetPattern = regexp.QuoteMeta(mayaAsset)
 		}
 
 		out.ParameterConstraints = []*types.ParameterConstraint{{
@@ -1198,7 +1199,7 @@ func (m *MetaRule) handleZcash(in *types.Rule, r *types.ResourcePath) ([]*types.
 			Constraint: &types.Constraint{
 				Type: types.ConstraintType_CONSTRAINT_TYPE_MAGIC_CONSTANT,
 				Value: &types.Constraint_MagicConstantValue{
-					MagicConstantValue: types.MagicConstant_THORCHAIN_VAULT,
+					MagicConstantValue: types.MagicConstant_MAYACHAIN_VAULT,
 				},
 			},
 		}, {

--- a/metarule/metarule_test.go
+++ b/metarule/metarule_test.go
@@ -3673,10 +3673,10 @@ func TestTryFormat_ZcashSwap(t *testing.T) {
 		paramByName[param.ParameterName] = param
 	}
 
-	// Output 0: vault address (magic constant)
+	// Output 0: vault address (magic constant) - Zcash uses MayaChain
 	assert.Contains(t, paramByName, "output_address_0")
 	assert.Equal(t, types.ConstraintType_CONSTRAINT_TYPE_MAGIC_CONSTANT, paramByName["output_address_0"].Constraint.Type)
-	assert.Equal(t, types.MagicConstant_THORCHAIN_VAULT, paramByName["output_address_0"].Constraint.GetMagicConstantValue())
+	assert.Equal(t, types.MagicConstant_MAYACHAIN_VAULT, paramByName["output_address_0"].Constraint.GetMagicConstantValue())
 
 	// Output 0: swap amount
 	assert.Contains(t, paramByName, "output_value_0")

--- a/sdk/zcash/zcash.go
+++ b/sdk/zcash/zcash.go
@@ -56,11 +56,11 @@ type UnsignedTx struct {
 	SigHashes [][]byte // Pre-computed signature hashes for each input
 }
 
-// ConsensusBranchID is the NU6 consensus branch ID for signature hash personalization.
+// ConsensusBranchID is the NU6.1 consensus branch ID for signature hash personalization.
 // Although we use v4 transactions (Sapling format), we must use the
 // consensus branch ID of the current epoch for signature hashing.
-// NU6 activated on November 23, 2024.
-const ConsensusBranchID = 0xC8E71055
+// NU6.1 activated on November 24, 2025 at block height 3146400.
+const ConsensusBranchID = 0x4dec4df0
 
 // Zcash v4 transaction constants
 const (


### PR DESCRIPTION
Bugs:
Recipes should check for typed UNSPECIFIED target instead of nil
Metarules should generate with maya related assets/magic constants
sdk should use newest ConsensusBranchID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated Zcash swap protocol integration to use MayaChain.
  * Added support for Zcash NU6.1 consensus parameters (activated November 24, 2025 at block height 3146400).

* **Bug Fixes**
  * Enhanced validation logic for Zcash rules to enforce unspecified target type handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->