### PR TITLE
fix: handle base58-encoded Solana tx data from LiFi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/gcash/bchutil v0.0.0-20250514010653-ef9bffba99e1
 	github.com/gtank/blake2 v0.1.1
 	github.com/kaptinlin/jsonschema v0.4.6
-	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.10.0
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
 	github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85
@@ -159,6 +158,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gcash/bchutil v0.0.0-20250514010653-ef9bffba99e1
 	github.com/gtank/blake2 v0.1.1
 	github.com/kaptinlin/jsonschema v0.4.6
+	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.10.0
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
 	github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85
@@ -158,7 +159,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
-	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a // indirect

--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/mr-tron/base58"
 )
 
 const (
@@ -278,8 +280,8 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 	// Check if approval is needed using consistent logic
 	needsApproval := IsApprovalRequired(req.Quote.FromAsset)
 
-	// Decode hex-encoded transaction data
-	txData, err := decodeLiFiHexData(quoteResp.TransactionRequest.Data)
+	// Decode transaction data (hex for EVM, base58 for Solana)
+	txData, err := decodeLiFiData(quoteResp.TransactionRequest.Data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode tx data: %w", err)
 	}
@@ -296,13 +298,22 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 	}, nil
 }
 
-// decodeLiFiHexData decodes a hex-encoded string (with optional 0x prefix) to bytes
-func decodeLiFiHexData(hexStr string) ([]byte, error) {
-	hexStr = strings.TrimPrefix(hexStr, "0x")
-	if hexStr == "" {
+// decodeLiFiData decodes transaction data returned by LiFi.
+// EVM chains return hex (with 0x prefix), Solana returns base58.
+func decodeLiFiData(data string) ([]byte, error) {
+	if data == "" {
 		return nil, nil
 	}
-	return hex.DecodeString(hexStr)
+	// Hex with 0x prefix (EVM chains)
+	if strings.HasPrefix(data, "0x") {
+		return hex.DecodeString(strings.TrimPrefix(data, "0x"))
+	}
+	// Try hex without prefix first
+	if decoded, err := hex.DecodeString(data); err == nil {
+		return decoded, nil
+	}
+	// Base58 (Solana)
+	return base58.Decode(data)
 }
 
 // LiFi API types

--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -279,7 +279,7 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 	// Check if approval is needed using consistent logic
 	needsApproval := IsApprovalRequired(req.Quote.FromAsset)
 
-	// Decode transaction data (hex for EVM, base58 for Solana)
+	// Decode transaction data (hex for EVM, base64 for Solana)
 	txData, err := decodeLiFiData(quoteResp.TransactionRequest.Data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode tx data: %w", err)

--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -2,6 +2,7 @@ package swap
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -11,8 +12,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/mr-tron/base58"
 )
 
 const (
@@ -299,7 +298,7 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 }
 
 // decodeLiFiData decodes transaction data returned by LiFi.
-// EVM chains return hex (with 0x prefix), Solana returns base58.
+// EVM chains return hex (with 0x prefix), Solana returns base64.
 func decodeLiFiData(data string) ([]byte, error) {
 	if data == "" {
 		return nil, nil
@@ -312,8 +311,8 @@ func decodeLiFiData(data string) ([]byte, error) {
 	if decoded, err := hex.DecodeString(data); err == nil {
 		return decoded, nil
 	}
-	// Base58 (Solana)
-	return base58.Decode(data)
+	// Base64 (Solana)
+	return base64.StdEncoding.DecodeString(data)
 }
 
 // LiFi API types


### PR DESCRIPTION
## Summary
- LiFi API returns base58-encoded transaction data for Solana chains, but `decodeLiFiHexData` only handled hex encoding
- SOL→ETH cross-chain swaps failed with `encoding/hex: invalid byte: U+0051 'Q'`
- Renamed to `decodeLiFiData` with auto-detection: `0x` prefix → hex, valid hex string → hex, otherwise → base58

## Test plan
- [ ] Verify EVM swaps still work (hex with 0x prefix)
- [ ] Test SOL→ETH cross-chain swap via LiFi
- [ ] Confirm `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced swap transaction data processing to support multiple encoding formats across different blockchains. The system now correctly handles transaction data from EVM-compatible chains and Solana networks, improving cross-chain swap reliability and compatibility. This ensures consistent and reliable transaction processing regardless of the blockchain network or data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->