### PR TITLE
fix: remove stale THORChain mainnet endpoint

### DIFF
--- a/sdk/cosmos/thorchain/thorchain.go
+++ b/sdk/cosmos/thorchain/thorchain.go
@@ -10,7 +10,6 @@ import (
 // THORChain mainnet endpoints (REST API)
 var MainnetEndpoints = []string{
 	"https://thornode.ninerealms.com",
-	"https://thornode.thorchain.info",
 }
 
 // THORChain stagenet endpoints

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -85,7 +85,6 @@ var thorChainNetworks = map[string]string{
 // Default THORChain endpoints
 var defaultTHORChainEndpoints = []string{
 	"https://thornode.ninerealms.com",
-	"https://thornode.thorchain.info",
 }
 
 // THORChainProvider implements SwapProvider for THORChain


### PR DESCRIPTION
## Summary
- remove `https://thornode.thorchain.info` from the THORChain mainnet endpoint lists in both the swap layer and Cosmos THOR client
- keep `https://thornode.ninerealms.com` as the remaining mainnet endpoint
- avoid falling through to a dead host during quote / inbound-address / THORChain RPC fallback paths

## Validation
- `rg -n "thornode\.thorchain\.info" -S .` returns no matches after the change
- `dscacheutil -q host -a name thornode.thorchain.info` returns no records locally
- `curl -I https://thornode.thorchain.info/thorchain/quote/swap` fails with `Could not resolve host`
- `curl -I https://thornode.ninerealms.com/thorchain/quote/swap` returns a live HTTP response

## Notes
- This does reduce mainnet failover to a single public THOR endpoint. That is intentional for now because the removed host appears dead; if there is another supported public fallback, we should add that separately.
- `go test ./sdk/swap/...` and `go build ./...` are currently blocked in this environment by an unrelated linker error from `github.com/bytedance/sonic/ast` (`invalid reference to encoding/json.unquoteBytes`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default THORChain REST API endpoints — removed an outdated endpoint and consolidated the default to a single, current mainnet endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->