### PR TITLE
feat: add optional THOR quote tolerance override

### DIFF
--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -48,8 +48,8 @@ type SwapParams struct {
 
 	// Preference specifies which providers to use and in what order.
 	// If nil, uses default provider order.
-	Preference *ProviderPreference
-	ToleranceBps *int
+	Preference   *ProviderPreference
+	ToleranceBps *int // Optional THOR/Maya quote tolerance override in basis points (typically 0-10000, where 10000 = 100%)
 }
 
 // SwapTx contains the transaction data ready for signing.

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -93,13 +93,13 @@ func (s *Service) GetSwapTx(ctx context.Context, params SwapParams) (*SwapTx, er
 
 	// Get quote
 	quote, err := s.router.GetQuote(ctx, QuoteRequest{
-		From:        from,
-		To:          to,
-		Amount:      params.Amount,
-		Sender:      params.Sender,
-		Destination: params.Destination,
+		From:         from,
+		To:           to,
+		Amount:       params.Amount,
+		Sender:       params.Sender,
+		Destination:  params.Destination,
 		ToleranceBps: params.ToleranceBps,
-		Preference:  params.Preference,
+		Preference:   params.Preference,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quote: %w", err)
@@ -304,13 +304,13 @@ func (s *Service) GetSwapTxBundle(ctx context.Context, params SwapParams) (*Swap
 
 	// Get quote
 	quote, err := s.router.GetQuote(ctx, QuoteRequest{
-		From:        from,
-		To:          to,
-		Amount:      params.Amount,
-		Sender:      params.Sender,
-		Destination: params.Destination,
+		From:         from,
+		To:           to,
+		Amount:       params.Amount,
+		Sender:       params.Sender,
+		Destination:  params.Destination,
 		ToleranceBps: params.ToleranceBps,
-		Preference:  params.Preference,
+		Preference:   params.Preference,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quote: %w", err)
@@ -357,13 +357,13 @@ func (s *Service) GetQuote(ctx context.Context, params SwapParams) (*Quote, erro
 	}
 
 	return s.router.GetQuote(ctx, QuoteRequest{
-		From:        from,
-		To:          to,
-		Amount:      params.Amount,
-		Sender:      params.Sender,
-		Destination: params.Destination,
+		From:         from,
+		To:           to,
+		Amount:       params.Amount,
+		Sender:       params.Sender,
+		Destination:  params.Destination,
 		ToleranceBps: params.ToleranceBps,
-		Preference:  params.Preference,
+		Preference:   params.Preference,
 	})
 }
 

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -49,6 +49,7 @@ type SwapParams struct {
 	// Preference specifies which providers to use and in what order.
 	// If nil, uses default provider order.
 	Preference *ProviderPreference
+	ToleranceBps *int
 }
 
 // SwapTx contains the transaction data ready for signing.
@@ -97,6 +98,7 @@ func (s *Service) GetSwapTx(ctx context.Context, params SwapParams) (*SwapTx, er
 		Amount:      params.Amount,
 		Sender:      params.Sender,
 		Destination: params.Destination,
+		ToleranceBps: params.ToleranceBps,
 		Preference:  params.Preference,
 	})
 	if err != nil {
@@ -307,6 +309,7 @@ func (s *Service) GetSwapTxBundle(ctx context.Context, params SwapParams) (*Swap
 		Amount:      params.Amount,
 		Sender:      params.Sender,
 		Destination: params.Destination,
+		ToleranceBps: params.ToleranceBps,
 		Preference:  params.Preference,
 	})
 	if err != nil {
@@ -359,6 +362,7 @@ func (s *Service) GetQuote(ctx context.Context, params SwapParams) (*Quote, erro
 		Amount:      params.Amount,
 		Sender:      params.Sender,
 		Destination: params.Destination,
+		ToleranceBps: params.ToleranceBps,
 		Preference:  params.Preference,
 	})
 }
@@ -373,4 +377,3 @@ func (s *Service) RequiresApproval(params SwapParams) bool {
 	}
 	return IsApprovalRequired(from)
 }
-

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -197,6 +197,9 @@ func (p *THORChainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	if req.ToleranceBps != nil {
 		toleranceBps = *req.ToleranceBps
 	}
+	if toleranceBps < 0 || toleranceBps > 10000 {
+		return nil, fmt.Errorf("invalid tolerance_bps %d: must be between 0 and 10000", toleranceBps)
+	}
 	params.Set("tolerance_bps", fmt.Sprintf("%d", toleranceBps))
 
 	// Try all endpoints with fallback

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -193,7 +193,11 @@ func (p *THORChainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	params.Set("destination", req.Destination)
 	params.Set("streaming_interval", "3")
 	params.Set("streaming_quantity", "0")
-	params.Set("tolerance_bps", "2500")
+	toleranceBps := 2500
+	if req.ToleranceBps != nil {
+		toleranceBps = *req.ToleranceBps
+	}
+	params.Set("tolerance_bps", fmt.Sprintf("%d", toleranceBps))
 
 	// Try all endpoints with fallback
 	var lastErr error

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -113,7 +113,7 @@ type QuoteRequest struct {
 	Amount      *big.Int // Amount in smallest unit (e.g., satoshis, wei)
 	Destination string   // Destination address for the swap output
 	Sender      string   // Sender address
-	ToleranceBps *int    // Optional THOR/Maya quote tolerance override
+	ToleranceBps *int    // Optional THOR/Maya quote tolerance override in basis points (typically 0-10000, where 10000 = 100%)
 
 	// Preference specifies which providers to use and in what order.
 	// If nil, uses default provider order.

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -108,12 +108,12 @@ func (p *BaseProvider) SupportsChain(chain string) bool {
 
 // QuoteRequest contains parameters for getting a swap quote
 type QuoteRequest struct {
-	From        Asset
-	To          Asset
-	Amount      *big.Int // Amount in smallest unit (e.g., satoshis, wei)
-	Destination string   // Destination address for the swap output
-	Sender      string   // Sender address
-	ToleranceBps *int    // Optional THOR/Maya quote tolerance override in basis points (typically 0-10000, where 10000 = 100%)
+	From         Asset
+	To           Asset
+	Amount       *big.Int // Amount in smallest unit (e.g., satoshis, wei)
+	Destination  string   // Destination address for the swap output
+	Sender       string   // Sender address
+	ToleranceBps *int     // Optional THOR/Maya quote tolerance override in basis points (typically 0-10000, where 10000 = 100%)
 
 	// Preference specifies which providers to use and in what order.
 	// If nil, uses default provider order.

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -113,6 +113,7 @@ type QuoteRequest struct {
 	Amount      *big.Int // Amount in smallest unit (e.g., satoshis, wei)
 	Destination string   // Destination address for the swap output
 	Sender      string   // Sender address
+	ToleranceBps *int    // Optional THOR/Maya quote tolerance override
 
 	// Preference specifies which providers to use and in what order.
 	// If nil, uses default provider order.
@@ -256,4 +257,3 @@ type SwapBundleRequest struct {
 	Nonce       *uint64  // Optional: starting nonce (fetched if nil)
 	GasPrice    *big.Int // Optional: gas price (fetched if nil)
 }
-


### PR DESCRIPTION
## Summary
- add an optional `ToleranceBps` override to `sdk/swap` quote inputs while keeping the existing `2500` default when callers omit it
- thread that optional value through `SwapParams` into the THOR quote request path
- let downstream callers like MCP opt into looser quote tolerance for tiny dev / agent swaps without changing current production behavior by default

## Why
Tiny swaps are currently brittle in backend-driven flows because THOR quote simulation can fail on price-limit grounds at the default tolerance. We do not want to globally widen that tolerance for every consumer of `recipes`.

This change keeps the current default intact and only adds an escape hatch for callers that explicitly choose to pass a higher value.

## Validation
- [x] `go build` of downstream `mcp` succeeds locally when pinned to this branch
- [x] local downstream MCP call can pass `tolerance_bps` and receive a THOR quote
- [ ] `go test ./sdk/swap/...` in this repo
  - blocked locally by existing linker error from `github.com/bytedance/sonic/ast`: `invalid reference to encoding/json.unquoteBytes`

## Notes
- No behavior changes for existing callers unless they explicitly pass `ToleranceBps`
- Follow-up MCP draft PR will consume this via an optional `tolerance_bps` tool arg for `build_swap_tx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now set a custom tolerance (in basis points) for swap quotes and transactions, giving finer control over acceptable slippage.
  * When not specified, a default tolerance is used.
  * Provided tolerances are validated to the 0–10000 range to prevent invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->