### PR TITLE
fix: li.fi Solana swap TX data decoded as hex instead of base64

### DIFF
--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -280,7 +280,7 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 	needsApproval := IsApprovalRequired(req.Quote.FromAsset)
 
 	// Decode transaction data (hex for EVM, base64 for Solana)
-	txData, err := decodeLiFiData(quoteResp.TransactionRequest.Data)
+	txData, err := decodeLiFiData(quoteResp.TransactionRequest.Data, req.Quote.FromAsset.Chain)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode tx data: %w", err)
 	}
@@ -299,7 +299,7 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 
 // decodeLiFiData decodes transaction data returned by LiFi.
 // EVM chains return hex (with 0x prefix), Solana returns base64.
-func decodeLiFiData(data string) ([]byte, error) {
+func decodeLiFiData(data string, chain string) ([]byte, error) {
 	if data == "" {
 		return nil, nil
 	}
@@ -307,11 +307,14 @@ func decodeLiFiData(data string) ([]byte, error) {
 	if strings.HasPrefix(data, "0x") {
 		return hex.DecodeString(strings.TrimPrefix(data, "0x"))
 	}
-	// Try hex without prefix first
+	// For non-EVM chains (Solana), prefer base64 decoding
+	if chain == "Solana" {
+		return base64.StdEncoding.DecodeString(data)
+	}
+	// Fallback: try hex without prefix, then base64
 	if decoded, err := hex.DecodeString(data); err == nil {
 		return decoded, nil
 	}
-	// Base64 (Solana)
 	return base64.StdEncoding.DecodeString(data)
 }
 

--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -311,11 +311,8 @@ func decodeLiFiData(data string, chain string) ([]byte, error) {
 	if chain == "Solana" {
 		return base64.StdEncoding.DecodeString(data)
 	}
-	// Fallback: try hex without prefix, then base64
-	if decoded, err := hex.DecodeString(data); err == nil {
-		return decoded, nil
-	}
-	return base64.StdEncoding.DecodeString(data)
+	// Non-Solana chains: must be hex (with or without 0x prefix)
+	return hex.DecodeString(data)
 }
 
 // LiFi API types


### PR DESCRIPTION
## Problem

`decodeLiFiData()` tried hex decode first for all chains. Solana TX data from LiFi is base64-encoded, but the hex decoder attempted to process it first. When it hit non-hex characters (like `Q` in the base64 string), it failed with:

```
encoding/hex: invalid byte: U+0051 'Q'
```

This prevented ALL Solana swaps from being built via LiFi.

## Fix

- Check the chain parameter and use base64 directly for Solana, bypassing the hex attempt entirely
- Non-Solana chains strictly require hex encoding (no base64 fallback that could silently corrupt data)

## Testing

### Wire up local recipes in your MCP

In `vultisig-mcp/go.mod`, ensure the replace directive points to your local recipes checkout:

```
replace github.com/vultisig/recipes => /path/to/your/recipes
```

### Build and run MCP locally

```bash
cd vultisig-mcp
go build -o /tmp/mcp-server ./cmd/mcp-server
/tmp/mcp-server --http :9091
```

### Curl BEFORE fix (on main) - fails

```bash
SESSION=$(curl -sD - -X POST http://localhost:9091/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
  | grep -i "Mcp-Session-Id" | awk '{print $2}' | tr -d '\r')

curl -s -X POST http://localhost:9091/mcp \
  -H "Content-Type: application/json" \
  -H "Mcp-Session-Id: $SESSION" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"build_swap_tx","arguments":{"from_chain":"Solana","from_symbol":"SOL","from_decimals":9,"to_chain":"Solana","to_symbol":"TRUMP","to_address":"6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN","to_decimals":6,"amount":"5920000","sender":"95NBfhAFppyXWYY3KdEZ8dvAdFnHLG8bKDqSbVMxnAQ5","destination":"95NBfhAFppyXWYY3KdEZ8dvAdFnHLG8bKDqSbVMxnAQ5"}}}'
# Result: "failed to decode tx data: encoding/hex: invalid byte: U+0051 'Q'"
```

### Curl AFTER fix (this branch) - succeeds

Same curl as above now returns a valid swap quote:

```json
{"provider":"LiFi","expected_output":"167841","chain":"Solana","swap_tx":{...}}
```

### EVM swaps unaffected

EVM swaps (ETH to VULT etc.) continue to work since they hit the `0x` prefix path.

## E2E verification

SOL to TRUMP swap via LiFi in VultiAgent app, confirmed as real swap on-chain (9 instructions, token balance changes):

https://solscan.io/tx/mt9tQWKR8XzKQDrWApuTNaM3XGR3cUNtHRfkLyCtenC8WnU3j3xiewghcyzQRoW4Ss2QMjeNLVXKKQnG1kat8Rm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable tolerance setting now available for THOR/Maya swap quotes (adjustable in basis points, 0-10000 range)

* **Bug Fixes**
  * Improved blockchain-specific data handling for swap transactions across different networks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->