### PR TITLE
feat: add relay.link as primary swap provider

### DIFF
--- a/sdk/swap/adapter.go
+++ b/sdk/swap/adapter.go
@@ -185,7 +185,7 @@ func (a *ChainAdapter) IsAvailable(ctx context.Context) (bool, error) {
 // GetStatus returns the status of swap providers for this chain.
 func (a *ChainAdapter) GetStatus(ctx context.Context) (*ProviderStatus, error) {
 	// Try providers in priority order
-	providers := providerOrder
+	providers := []string{"THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
 
 	for _, p := range providers {
 		status, err := a.router.GetProviderStatus(ctx, p, a.chain)

--- a/sdk/swap/adapter.go
+++ b/sdk/swap/adapter.go
@@ -185,7 +185,7 @@ func (a *ChainAdapter) IsAvailable(ctx context.Context) (bool, error) {
 // GetStatus returns the status of swap providers for this chain.
 func (a *ChainAdapter) GetStatus(ctx context.Context) (*ProviderStatus, error) {
 	// Try providers in priority order
-	providers := []string{"THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
+	providers := []string{"Relay", "THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
 
 	for _, p := range providers {
 		status, err := a.router.GetProviderStatus(ctx, p, a.chain)

--- a/sdk/swap/adapter.go
+++ b/sdk/swap/adapter.go
@@ -185,7 +185,7 @@ func (a *ChainAdapter) IsAvailable(ctx context.Context) (bool, error) {
 // GetStatus returns the status of swap providers for this chain.
 func (a *ChainAdapter) GetStatus(ctx context.Context) (*ProviderStatus, error) {
 	// Try providers in priority order
-	providers := []string{"Relay", "THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
+	providers := providerOrder
 
 	for _, p := range providers {
 		status, err := a.router.GetProviderStatus(ctx, p, a.chain)

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -1,0 +1,488 @@
+package swap
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/gagliardetto/solana-go"
+	addresslookuptable "github.com/gagliardetto/solana-go/programs/address-lookup-table"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+const (
+	relayDefaultBaseURL = "https://api.relay.link"
+	relayReferrer       = "vultisig"
+)
+
+// Relay chain IDs (subset of 75+ supported chains).
+var relayChainIDs = map[string]int{
+	"Ethereum":  1,
+	"BSC":       56,
+	"Polygon":   137,
+	"Avalanche": 43114,
+	"Arbitrum":  42161,
+	"Optimism":  10,
+	"Base":      8453,
+	"Mantle":    5000,
+	"Zksync":    324,
+	"Sei":       1329,
+	"Solana":    792703809,
+}
+
+// Relay supported chains
+var relaySupportedChains = func() []string {
+	chains := make([]string, 0, len(relayChainIDs))
+	for chain := range relayChainIDs {
+		chains = append(chains, chain)
+	}
+	return chains
+}()
+
+// RelayProvider implements SwapProvider for the Relay.link cross-chain swap API.
+// Relay is solver-based: quoted amounts are guaranteed by the solver network,
+// so MinimumOutput == ExpectedOutput (no AMM slippage).
+// No API key required.
+type RelayProvider struct {
+	BaseProvider
+	client  *http.Client
+	baseURL string
+	solRPC  *rpc.Client // needed for Solana TX assembly (blockhash + ALT resolution)
+}
+
+// NewRelayProvider creates a new Relay provider.
+// solRPC is only needed for Solana swaps (pass nil for EVM-only usage).
+func NewRelayProvider(solRPC *rpc.Client) *RelayProvider {
+	return &RelayProvider{
+		BaseProvider: NewBaseProvider("Relay", PriorityRelay, relaySupportedChains),
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		baseURL: relayDefaultBaseURL,
+		solRPC:  solRPC,
+	}
+}
+
+// SupportsRoute checks if Relay can handle a swap between two assets
+func (p *RelayProvider) SupportsRoute(from, to Asset) bool {
+	return p.SupportsChain(from.Chain) && p.SupportsChain(to.Chain)
+}
+
+// IsAvailable checks if Relay is available for a specific chain.
+// Relay is generally always available if the chain is supported.
+func (p *RelayProvider) IsAvailable(ctx context.Context, chain string) (bool, error) {
+	return p.SupportsChain(chain), nil
+}
+
+// GetStatus returns detailed availability status for a chain
+func (p *RelayProvider) GetStatus(ctx context.Context, chain string) (*ProviderStatus, error) {
+	return &ProviderStatus{
+		Chain:     chain,
+		Available: p.SupportsChain(chain),
+	}, nil
+}
+
+// GetQuote gets a swap quote from Relay
+func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, error) {
+	originChainID, ok := relayChainIDs[req.From.Chain]
+	if !ok {
+		return nil, fmt.Errorf("relay: unsupported origin chain %q", req.From.Chain)
+	}
+	destChainID, ok := relayChainIDs[req.To.Chain]
+	if !ok {
+		return nil, fmt.Errorf("relay: unsupported destination chain %q", req.To.Chain)
+	}
+
+	originCurrency := req.From.Address
+	if originCurrency == "" {
+		originCurrency = relayNativeAddress(req.From.Chain)
+	}
+	destCurrency := req.To.Address
+	if destCurrency == "" {
+		destCurrency = relayNativeAddress(req.To.Chain)
+	}
+
+	quoteReq := relayQuoteRequest{
+		User:                req.Sender,
+		OriginChainID:       originChainID,
+		DestinationChainID:  destChainID,
+		OriginCurrency:      originCurrency,
+		DestinationCurrency: destCurrency,
+		Amount:              req.Amount.String(),
+		TradeType:           "EXACT_INPUT",
+		Recipient:           req.Destination,
+		Referrer:            relayReferrer,
+	}
+
+	quoteResp, err := p.postQuote(ctx, quoteReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse expected output amount
+	expectedOutput, ok := new(big.Int).SetString(quoteResp.Details.CurrencyOut.Amount, 10)
+	if !ok {
+		return nil, fmt.Errorf("relay: invalid output amount %q", quoteResp.Details.CurrencyOut.Amount)
+	}
+
+	// Separate approval and swap transaction steps.
+	var approvalStep *relayStepData
+	var txStep *relayStepData
+	for i := range quoteResp.Steps {
+		step := &quoteResp.Steps[i]
+		if len(step.Items) == 0 {
+			continue
+		}
+		if step.ID == "approve" {
+			approvalStep = &step.Items[0].Data
+		} else if step.Kind == "transaction" && txStep == nil {
+			txStep = &step.Items[0].Data
+		}
+	}
+
+	// Check if approval is needed from the Relay response
+	needsApproval := approvalStep != nil
+	var approvalSpender string
+	if needsApproval {
+		approvalSpender = approvalStep.To
+	}
+
+	// Store the full quote response as ProviderData so BuildTx doesn't re-fetch.
+	providerData, _ := json.Marshal(quoteResp)
+
+	quote := &Quote{
+		Provider:        p.Name(),
+		FromAsset:       req.From,
+		ToAsset:         req.To,
+		FromAmount:      req.Amount,
+		ExpectedOutput:  expectedOutput,
+		MinimumOutput:   expectedOutput, // Relay is solver-based: no AMM slippage
+		NeedsApproval:   needsApproval,
+		ApprovalSpender: approvalSpender,
+		ApprovalAmount:  req.Amount,
+		ProviderData:    providerData,
+	}
+
+	return quote, nil
+}
+
+// BuildTx builds an unsigned transaction for the swap
+func (p *RelayProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResult, error) {
+	if req.Quote == nil {
+		return nil, fmt.Errorf("quote is required")
+	}
+
+	// Restore the cached quote response from ProviderData.
+	var quoteResp relayQuoteResponse
+	if len(req.Quote.ProviderData) > 0 {
+		if err := json.Unmarshal(req.Quote.ProviderData, &quoteResp); err != nil {
+			return nil, fmt.Errorf("relay: unmarshal provider data: %w", err)
+		}
+	} else {
+		// Fallback: re-fetch quote (shouldn't happen in normal flow).
+		return nil, fmt.Errorf("relay: missing provider data, call GetQuote first")
+	}
+
+	// Find the swap transaction step.
+	var approvalStep *relayStepData
+	var txStep *relayStepData
+	for i := range quoteResp.Steps {
+		step := &quoteResp.Steps[i]
+		if len(step.Items) == 0 {
+			continue
+		}
+		if step.ID == "approve" {
+			approvalStep = &step.Items[0].Data
+		} else if step.Kind == "transaction" && txStep == nil {
+			txStep = &step.Items[0].Data
+		}
+	}
+	if txStep == nil {
+		return nil, fmt.Errorf("relay: no transaction step in quote response")
+	}
+
+	fromChain := req.Quote.FromAsset.Chain
+
+	// Build the result based on chain type.
+	if fromChain == "Solana" {
+		txData, err := p.buildSolanaTransaction(ctx, txStep, req.Sender)
+		if err != nil {
+			return nil, fmt.Errorf("relay: build solana tx: %w", err)
+		}
+		return &SwapResult{
+			Provider:    p.Name(),
+			TxData:      txData,
+			Value:       big.NewInt(0),
+			ToAddress:   "", // Solana: program addresses are in the instructions
+			ExpectedOut: req.Quote.ExpectedOutput,
+		}, nil
+	}
+
+	// EVM chains
+	value := big.NewInt(0)
+	if txStep.Value != "" {
+		var ok bool
+		value, ok = new(big.Int).SetString(txStep.Value, 0)
+		if !ok {
+			value = big.NewInt(0)
+		}
+	}
+
+	// Decode EVM calldata
+	txData, err := hex.DecodeString(trimHexPrefix(txStep.Data))
+	if err != nil {
+		return nil, fmt.Errorf("relay: decode tx data: %w", err)
+	}
+
+	result := &SwapResult{
+		Provider:    p.Name(),
+		TxData:      txData,
+		Value:       value,
+		ToAddress:   txStep.To,
+		ExpectedOut: req.Quote.ExpectedOutput,
+	}
+
+	// Populate approval info from the cached response.
+	if approvalStep != nil {
+		result.NeedsApproval = true
+		result.ApprovalAddress = approvalStep.To
+
+		approvalAmount := req.Quote.FromAmount
+		if approvalAmount == nil {
+			approvalAmount = big.NewInt(0)
+		}
+		result.ApprovalAmount = approvalAmount
+	}
+
+	return result, nil
+}
+
+// buildSolanaTransaction assembles a VersionedTransaction from Relay response instructions.
+func (p *RelayProvider) buildSolanaTransaction(ctx context.Context, txData *relayStepData, senderAddr string) ([]byte, error) {
+	if p.solRPC == nil {
+		return nil, fmt.Errorf("solana RPC client required for Solana swaps")
+	}
+
+	feePayer, err := solana.PublicKeyFromBase58(senderAddr)
+	if err != nil {
+		return nil, fmt.Errorf("parse sender address: %w", err)
+	}
+
+	// Convert Relay instructions to solana-go instructions.
+	instructions := make([]solana.Instruction, 0, len(txData.Instructions))
+	for i, inst := range txData.Instructions {
+		programID, err := solana.PublicKeyFromBase58(inst.ProgramID)
+		if err != nil {
+			return nil, fmt.Errorf("parse program id for instruction %d: %w", i, err)
+		}
+
+		accounts := make([]*solana.AccountMeta, 0, len(inst.Keys))
+		for _, key := range inst.Keys {
+			pk, err := solana.PublicKeyFromBase58(key.Pubkey)
+			if err != nil {
+				return nil, fmt.Errorf("parse account key %s: %w", key.Pubkey, err)
+			}
+			accounts = append(accounts, solana.NewAccountMeta(pk, key.IsWritable, key.IsSigner))
+		}
+
+		// Relay returns instruction data as hex-encoded string (no 0x prefix).
+		data, err := hex.DecodeString(inst.Data)
+		if err != nil {
+			return nil, fmt.Errorf("decode instruction data %d: %w", i, err)
+		}
+
+		instructions = append(instructions, solana.NewInstruction(programID, accounts, data))
+	}
+
+	// Fetch recent blockhash.
+	block, err := p.solRPC.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		return nil, fmt.Errorf("get latest blockhash: %w", err)
+	}
+
+	opts := []solana.TransactionOption{
+		solana.TransactionPayer(feePayer),
+	}
+
+	// Resolve address lookup tables if present.
+	if len(txData.AddressLookupTableAddresses) > 0 {
+		altMap, err := resolveRelayALTs(ctx, p.solRPC, txData.AddressLookupTableAddresses)
+		if err != nil {
+			return nil, fmt.Errorf("resolve address lookup tables: %w", err)
+		}
+		opts = append(opts, solana.TransactionAddressTables(altMap))
+	}
+
+	tx, err := solana.NewTransaction(instructions, block.Value.Blockhash, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create solana transaction: %w", err)
+	}
+
+	txBytes, err := tx.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("marshal solana transaction: %w", err)
+	}
+
+	return txBytes, nil
+}
+
+// resolveRelayALTs fetches address lookup table accounts from the Solana chain.
+func resolveRelayALTs(ctx context.Context, solRPC *rpc.Client, altAddresses []string) (map[solana.PublicKey]solana.PublicKeySlice, error) {
+	result := make(map[solana.PublicKey]solana.PublicKeySlice, len(altAddresses))
+
+	for _, addr := range altAddresses {
+		pk, err := solana.PublicKeyFromBase58(addr)
+		if err != nil {
+			return nil, fmt.Errorf("parse ALT address %s: %w", addr, err)
+		}
+
+		state, err := addresslookuptable.GetAddressLookupTableStateWithOpts(ctx, solRPC, pk, &rpc.GetAccountInfoOpts{
+			Commitment: rpc.CommitmentFinalized,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("fetch ALT %s: %w", addr, err)
+		}
+
+		result[pk] = state.Addresses
+	}
+
+	return result, nil
+}
+
+// postQuote calls POST /quote on the Relay API.
+func (p *RelayProvider) postQuote(ctx context.Context, req relayQuoteRequest) (*relayQuoteResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("relay: marshal quote request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/quote", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("relay: create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("relay: http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("relay: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("relay: api error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var quoteResp relayQuoteResponse
+	if err := json.Unmarshal(respBody, &quoteResp); err != nil {
+		return nil, fmt.Errorf("relay: parse quote response: %w", err)
+	}
+
+	return &quoteResp, nil
+}
+
+// relayNativeAddress returns the native currency address for a chain on Relay.
+func relayNativeAddress(chain string) string {
+	if chain == "Solana" {
+		return "11111111111111111111111111111111"
+	}
+	return "0x0000000000000000000000000000000000000000"
+}
+
+// trimHexPrefix removes a "0x" prefix from hex data if present.
+func trimHexPrefix(s string) string {
+	if len(s) >= 2 && s[:2] == "0x" {
+		return s[2:]
+	}
+	return s
+}
+
+// RelayChainID returns the Relay chain ID for the given chain name.
+// Exported for use by MCP or other consumers that need chain ID mapping.
+func RelayChainID(chain string) (int, bool) {
+	id, ok := relayChainIDs[chain]
+	return id, ok
+}
+
+// --- Relay API types ---
+
+type relayQuoteRequest struct {
+	User                string `json:"user"`
+	OriginChainID       int    `json:"originChainId"`
+	DestinationChainID  int    `json:"destinationChainId"`
+	OriginCurrency      string `json:"originCurrency"`
+	DestinationCurrency string `json:"destinationCurrency"`
+	Amount              string `json:"amount"`
+	TradeType           string `json:"tradeType"`
+	Recipient           string `json:"recipient"`
+	Referrer            string `json:"referrer"`
+}
+
+type relayQuoteResponse struct {
+	Steps   []relayStep   `json:"steps"`
+	Details relayDetails  `json:"details"`
+}
+
+type relayStep struct {
+	ID    string          `json:"id"`
+	Kind  string          `json:"kind"`
+	Items []relayStepItem `json:"items"`
+}
+
+type relayStepItem struct {
+	Data relayStepData `json:"data"`
+}
+
+// relayStepData contains the raw transaction fields from Relay.
+// For EVM: From/To/Data/Value are populated.
+// For Solana: Instructions and AddressLookupTableAddresses are populated.
+type relayStepData struct {
+	// EVM fields
+	From  string `json:"from,omitempty"`
+	To    string `json:"to,omitempty"`
+	Data  string `json:"data,omitempty"`
+	Value string `json:"value,omitempty"`
+
+	// Solana fields
+	Instructions                []relaySolInstruction `json:"instructions,omitempty"`
+	AddressLookupTableAddresses []string              `json:"addressLookupTableAddresses,omitempty"`
+}
+
+type relaySolInstruction struct {
+	Keys      []relaySolAccountKey `json:"keys"`
+	ProgramID string               `json:"programId"`
+	Data      string               `json:"data"`
+}
+
+type relaySolAccountKey struct {
+	Pubkey     string `json:"pubkey"`
+	IsSigner   bool   `json:"isSigner"`
+	IsWritable bool   `json:"isWritable"`
+}
+
+type relayDetails struct {
+	CurrencyOut  relayCurrencyOut `json:"currencyOut"`
+	Rate         string           `json:"rate"`
+	TimeEstimate int              `json:"timeEstimate"`
+}
+
+type relayCurrencyOut struct {
+	Amount          string            `json:"amount"`
+	AmountFormatted string            `json:"amountFormatted"`
+	Currency        relayCurrencyMeta `json:"currency"`
+}
+
+type relayCurrencyMeta struct {
+	Symbol string `json:"symbol"`
+}

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -21,7 +21,7 @@ const (
 	relayReferrer       = "vultisig"
 )
 
-// Relay chain IDs (subset of 75+ supported chains).
+// Relay chain IDs
 var relayChainIDs = map[string]int{
 	"Ethereum":  1,
 	"BSC":       56,
@@ -36,7 +36,7 @@ var relayChainIDs = map[string]int{
 	"Solana":    792703809,
 }
 
-// relaySupportedEVMChains lists all Relay-supported chains except Solana.
+// relaySupportedEVMChains excludes Solana (used when solRPC is nil).
 var relaySupportedEVMChains = func() []string {
 	chains := make([]string, 0, len(relayChainIDs)-1)
 	for chain := range relayChainIDs {
@@ -47,7 +47,7 @@ var relaySupportedEVMChains = func() []string {
 	return chains
 }()
 
-// relaySupportedAllChains includes Solana (requires solRPC).
+// relaySupportedAllChains includes Solana.
 var relaySupportedAllChains = func() []string {
 	chains := make([]string, 0, len(relayChainIDs))
 	for chain := range relayChainIDs {
@@ -56,19 +56,15 @@ var relaySupportedAllChains = func() []string {
 	return chains
 }()
 
-// RelayProvider implements SwapProvider for the Relay.link cross-chain swap API.
-// Relay is solver-based: quoted amounts are guaranteed by the solver network,
-// so MinimumOutput == ExpectedOutput (no AMM slippage).
-// No API key required.
+// RelayProvider implements SwapProvider for Relay.link
 type RelayProvider struct {
 	BaseProvider
 	client  *http.Client
 	baseURL string
-	solRPC  *rpc.Client // needed for Solana TX assembly (blockhash + ALT resolution)
+	solRPC  *rpc.Client
 }
 
-// NewRelayProvider creates a new Relay provider.
-// solRPC is only needed for Solana swaps (pass nil for EVM-only usage).
+// NewRelayProvider creates a new Relay provider
 func NewRelayProvider(solRPC *rpc.Client) *RelayProvider {
 	chains := relaySupportedEVMChains
 	if solRPC != nil {
@@ -89,8 +85,7 @@ func (p *RelayProvider) SupportsRoute(from, to Asset) bool {
 	return p.SupportsChain(from.Chain) && p.SupportsChain(to.Chain)
 }
 
-// IsAvailable checks if Relay is available for a specific chain.
-// Relay is generally always available if the chain is supported.
+// IsAvailable checks if Relay is available for a specific chain
 func (p *RelayProvider) IsAvailable(ctx context.Context, chain string) (bool, error) {
 	return p.SupportsChain(chain), nil
 }
@@ -161,22 +156,20 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		}
 	}
 
-	// Check if approval is needed from the Relay response.
-	// The spender is the swap TX destination (Relay router), not the approval TX
-	// destination (which is the token contract receiving the approve() call).
+	// Spender is the swap TX destination (router), not the approval TX target (token contract).
 	needsApproval := approvalStep != nil
 	var approvalSpender string
 	if needsApproval && txStep != nil {
 		approvalSpender = txStep.To
 	}
 
-	// Store the full quote response as ProviderData so BuildTx doesn't re-fetch.
+	// Cache quote response in ProviderData for BuildTx.
 	providerData, err := json.Marshal(quoteResp)
 	if err != nil {
 		return nil, fmt.Errorf("relay: marshal provider data: %w", err)
 	}
 
-	// Router is the swap TX destination (Relay router contract).
+	// Router address for approval spender resolution.
 	var router string
 	if txStep != nil {
 		router = txStep.To
@@ -205,14 +198,14 @@ func (p *RelayProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResu
 		return nil, fmt.Errorf("quote is required")
 	}
 
-	// Restore the cached quote response from ProviderData.
+	// Restore cached quote response.
 	var quoteResp relayQuoteResponse
 	if len(req.Quote.ProviderData) > 0 {
 		if err := json.Unmarshal(req.Quote.ProviderData, &quoteResp); err != nil {
 			return nil, fmt.Errorf("relay: unmarshal provider data: %w", err)
 		}
 	} else {
-		// Fallback: re-fetch quote (shouldn't happen in normal flow).
+		// Should not happen — GetQuote always sets ProviderData.
 		return nil, fmt.Errorf("relay: missing provider data, call GetQuote first")
 	}
 
@@ -418,8 +411,7 @@ func (p *RelayProvider) postQuote(ctx context.Context, req relayQuoteRequest) (*
 	return &quoteResp, nil
 }
 
-// relayNativeAddress returns the native currency address for a chain on Relay.
-// Solana uses the System Program address (not Wrapped SOL mint) per Relay API convention.
+// relayNativeAddress returns the Relay native currency address for a chain.
 func relayNativeAddress(chain string) string {
 	if chain == "Solana" {
 		return "11111111111111111111111111111111"
@@ -465,8 +457,6 @@ type relayStepItem struct {
 }
 
 // relayStepData contains the raw transaction fields from Relay.
-// For EVM: From/To/Data/Value are populated.
-// For Solana: Instructions and AddressLookupTableAddresses are populated.
 type relayStepData struct {
 	// EVM fields
 	From  string `json:"from,omitempty"`

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -161,17 +161,25 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		}
 	}
 
-	// Check if approval is needed from the Relay response
+	// Check if approval is needed from the Relay response.
+	// The spender is the swap TX destination (Relay router), not the approval TX
+	// destination (which is the token contract receiving the approve() call).
 	needsApproval := approvalStep != nil
 	var approvalSpender string
-	if needsApproval {
-		approvalSpender = approvalStep.To
+	if needsApproval && txStep != nil {
+		approvalSpender = txStep.To
 	}
 
 	// Store the full quote response as ProviderData so BuildTx doesn't re-fetch.
 	providerData, err := json.Marshal(quoteResp)
 	if err != nil {
 		return nil, fmt.Errorf("relay: marshal provider data: %w", err)
+	}
+
+	// Router is the swap TX destination (Relay router contract).
+	var router string
+	if txStep != nil {
+		router = txStep.To
 	}
 
 	quote := &Quote{
@@ -181,6 +189,7 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		FromAmount:      req.Amount,
 		ExpectedOutput:  expectedOutput,
 		MinimumOutput:   expectedOutput, // Relay is solver-based: no AMM slippage
+		Router:          router,
 		NeedsApproval:   needsApproval,
 		ApprovalSpender: approvalSpender,
 		ApprovalAmount:  req.Amount,
@@ -425,13 +434,6 @@ func trimHexPrefix(s string) string {
 		return s[2:]
 	}
 	return s
-}
-
-// RelayChainID returns the Relay chain ID for the given chain name.
-// Exported for use by MCP or other consumers that need chain ID mapping.
-func RelayChainID(chain string) (int, bool) {
-	id, ok := relayChainIDs[chain]
-	return id, ok
 }
 
 // --- Relay API types ---

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -154,7 +154,10 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 	}
 
 	// Store the full quote response as ProviderData so BuildTx doesn't re-fetch.
-	providerData, _ := json.Marshal(quoteResp)
+	providerData, err := json.Marshal(quoteResp)
+	if err != nil {
+		return nil, fmt.Errorf("relay: marshal provider data: %w", err)
+	}
 
 	quote := &Quote{
 		Provider:        p.Name(),
@@ -230,7 +233,7 @@ func (p *RelayProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResu
 		var ok bool
 		value, ok = new(big.Int).SetString(txStep.Value, 0)
 		if !ok {
-			value = big.NewInt(0)
+			return nil, fmt.Errorf("relay: invalid tx value %q", txStep.Value)
 		}
 	}
 
@@ -291,8 +294,8 @@ func (p *RelayProvider) buildSolanaTransaction(ctx context.Context, txData *rela
 			accounts = append(accounts, solana.NewAccountMeta(pk, key.IsWritable, key.IsSigner))
 		}
 
-		// Relay returns instruction data as hex-encoded string (no 0x prefix).
-		data, err := hex.DecodeString(inst.Data)
+		// Relay returns instruction data as hex-encoded string (typically no 0x prefix).
+		data, err := hex.DecodeString(trimHexPrefix(inst.Data))
 		if err != nil {
 			return nil, fmt.Errorf("decode instruction data %d: %w", i, err)
 		}
@@ -393,6 +396,7 @@ func (p *RelayProvider) postQuote(ctx context.Context, req relayQuoteRequest) (*
 }
 
 // relayNativeAddress returns the native currency address for a chain on Relay.
+// Solana uses the System Program address (not Wrapped SOL mint) per Relay API convention.
 func relayNativeAddress(chain string) string {
 	if chain == "Solana" {
 		return "11111111111111111111111111111111"

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -36,8 +36,19 @@ var relayChainIDs = map[string]int{
 	"Solana":    792703809,
 }
 
-// Relay supported chains
-var relaySupportedChains = func() []string {
+// relaySupportedEVMChains lists all Relay-supported chains except Solana.
+var relaySupportedEVMChains = func() []string {
+	chains := make([]string, 0, len(relayChainIDs)-1)
+	for chain := range relayChainIDs {
+		if chain != "Solana" {
+			chains = append(chains, chain)
+		}
+	}
+	return chains
+}()
+
+// relaySupportedAllChains includes Solana (requires solRPC).
+var relaySupportedAllChains = func() []string {
 	chains := make([]string, 0, len(relayChainIDs))
 	for chain := range relayChainIDs {
 		chains = append(chains, chain)
@@ -59,8 +70,12 @@ type RelayProvider struct {
 // NewRelayProvider creates a new Relay provider.
 // solRPC is only needed for Solana swaps (pass nil for EVM-only usage).
 func NewRelayProvider(solRPC *rpc.Client) *RelayProvider {
+	chains := relaySupportedEVMChains
+	if solRPC != nil {
+		chains = relaySupportedAllChains
+	}
 	return &RelayProvider{
-		BaseProvider: NewBaseProvider("Relay", PriorityRelay, relaySupportedChains),
+		BaseProvider: NewBaseProvider("Relay", PriorityRelay, chains),
 		client: &http.Client{
 			Timeout: 15 * time.Second,
 		},

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -371,7 +371,7 @@ func (p *RelayProvider) postQuote(ctx context.Context, req relayQuoteRequest) (*
 		return nil, fmt.Errorf("relay: marshal quote request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/quote", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/quote/v2", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("relay: create request: %w", err)
 	}

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -36,18 +36,7 @@ var relayChainIDs = map[string]int{
 	"Solana":    792703809,
 }
 
-// relaySupportedEVMChains excludes Solana (used when solRPC is nil).
-var relaySupportedEVMChains = func() []string {
-	chains := make([]string, 0, len(relayChainIDs)-1)
-	for chain := range relayChainIDs {
-		if chain != "Solana" {
-			chains = append(chains, chain)
-		}
-	}
-	return chains
-}()
-
-// relaySupportedAllChains includes Solana.
+// relaySupportedAllChains lists all Relay-supported chains.
 var relaySupportedAllChains = func() []string {
 	chains := make([]string, 0, len(relayChainIDs))
 	for chain := range relayChainIDs {
@@ -66,12 +55,8 @@ type RelayProvider struct {
 
 // NewRelayProvider creates a new Relay provider
 func NewRelayProvider(solRPC *rpc.Client) *RelayProvider {
-	chains := relaySupportedEVMChains
-	if solRPC != nil {
-		chains = relaySupportedAllChains
-	}
 	return &RelayProvider{
-		BaseProvider: NewBaseProvider("Relay", PriorityRelay, chains),
+		BaseProvider: NewBaseProvider("Relay", PriorityRelay, relaySupportedAllChains),
 		client: &http.Client{
 			Timeout: 15 * time.Second,
 		},
@@ -118,6 +103,11 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		destCurrency = relayNativeAddress(req.To.Chain)
 	}
 
+	recipient := req.Destination
+	if recipient == "" {
+		recipient = req.Sender
+	}
+
 	quoteReq := relayQuoteRequest{
 		User:                req.Sender,
 		OriginChainID:       originChainID,
@@ -126,7 +116,7 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		DestinationCurrency: destCurrency,
 		Amount:              req.Amount.String(),
 		TradeType:           "EXACT_INPUT",
-		Recipient:           req.Destination,
+		Recipient:           recipient,
 		Referrer:            relayReferrer,
 	}
 

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -280,11 +280,10 @@ func (p *RelayProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResu
 		result.NeedsApproval = true
 		result.ApprovalAddress = approvalStep.To
 
-		approvalAmount := req.Quote.FromAmount
-		if approvalAmount == nil {
-			approvalAmount = big.NewInt(0)
+		if req.Quote.FromAmount == nil {
+			return nil, fmt.Errorf("relay: approval required but FromAmount is nil")
 		}
-		result.ApprovalAmount = approvalAmount
+		result.ApprovalAmount = req.Quote.FromAmount
 	}
 
 	return result, nil

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -371,7 +371,7 @@ func (p *RelayProvider) postQuote(ctx context.Context, req relayQuoteRequest) (*
 		return nil, fmt.Errorf("relay: marshal quote request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/quote/v2", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/quote", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("relay: create request: %w", err)
 	}

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -33,13 +33,13 @@ const (
 
 // providerOrder defines the preferred provider order for ALL swaps.
 // THORChain/Mayachain are tried first (if they support the route),
-// then Relay and LiFi as multi-chain aggregators, then DEX fallbacks.
+// then fall back to DEX aggregators for same-chain swaps.
 var providerOrder = []string{
-	ProviderTHORChain, // Cross-chain protocol first
+	ProviderTHORChain, // Try cross-chain protocol first
 	ProviderMayachain, // Alternative cross-chain
 	ProviderRelay,     // Solver-based multi-chain (before LiFi)
-	ProviderOneInch,   // Same-chain EVM
-	ProviderJupiter,   // Solana DEX
+	ProviderOneInch,   // Fallback for same-chain EVM
+	ProviderJupiter,   // Fallback for Solana
 	ProviderLiFi,      // Multi-chain aggregator
 	ProviderUniswap,   // Last resort DEX
 }

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+
+	"github.com/gagliardetto/solana-go/rpc"
 )
 
 var (
@@ -75,10 +77,15 @@ func NewRouter(opts ...RouterOption) *Router {
 	return r
 }
 
-// NewDefaultRouter creates a router with all default providers
-func NewDefaultRouter() *Router {
+// NewDefaultRouter creates a router with all default providers.
+// Optional solRPC enables Relay Solana TX assembly (pass nil for EVM-only Relay).
+func NewDefaultRouter(solRPC ...*rpc.Client) *Router {
+	var sol *rpc.Client
+	if len(solRPC) > 0 {
+		sol = solRPC[0]
+	}
 	return NewRouter(
-		WithProvider(NewRelayProvider(nil)),
+		WithProvider(NewRelayProvider(sol)),
 		WithProvider(NewTHORChainProvider(nil)),
 		WithProvider(NewMayachainProvider(nil)),
 		WithProvider(NewLiFiProvider("")),

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -77,9 +77,7 @@ func NewRouter(opts ...RouterOption) *Router {
 	return r
 }
 
-// NewDefaultRouter creates a router with all default providers.
-// Relay requires a Solana RPC client for Solana swaps but works without one for EVM-only.
-// Use NewDefaultRouterWithSolana to provide a Solana RPC client.
+// NewDefaultRouter creates a router with all default providers (Relay EVM-only).
 func NewDefaultRouter() *Router {
 	return NewRouter(
 		WithProvider(NewRelayProvider(nil)),
@@ -92,8 +90,7 @@ func NewDefaultRouter() *Router {
 	)
 }
 
-// NewDefaultRouterWithSolana creates a router with all default providers,
-// including Solana RPC support for Relay Solana swaps.
+// NewDefaultRouterWithSolana creates a router with Relay Solana support.
 func NewDefaultRouterWithSolana(solRPC *rpc.Client) *Router {
 	return NewRouter(
 		WithProvider(NewRelayProvider(solRPC)),

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+
+	"github.com/gagliardetto/solana-go/rpc"
 )
 
 var (
@@ -20,6 +22,7 @@ var (
 
 // Provider names for routing logic - must match names used in NewBaseProvider calls
 const (
+	ProviderRelay     = "Relay"
 	ProviderTHORChain = "THORChain"
 	ProviderMayachain = "Mayachain"
 	ProviderLiFi      = "LiFi"
@@ -29,10 +32,11 @@ const (
 )
 
 // providerOrder defines the preferred provider order for ALL swaps.
-// THORChain/Mayachain are tried first (if they support the route),
-// then fall back to DEX aggregators for same-chain swaps.
+// Relay is tried first (solver-based, no slippage), then THORChain/Mayachain
+// for cross-chain, then DEX aggregators for same-chain swaps.
 var providerOrder = []string{
-	ProviderTHORChain, // Try cross-chain protocol first
+	ProviderRelay,     // Solver-based, no slippage, 75+ chains
+	ProviderTHORChain, // Cross-chain protocol
 	ProviderMayachain, // Alternative cross-chain
 	ProviderOneInch,   // Fallback for same-chain EVM
 	ProviderJupiter,   // Fallback for Solana
@@ -73,9 +77,26 @@ func NewRouter(opts ...RouterOption) *Router {
 	return r
 }
 
-// NewDefaultRouter creates a router with all default providers
+// NewDefaultRouter creates a router with all default providers.
+// Relay requires a Solana RPC client for Solana swaps but works without one for EVM-only.
+// Use NewDefaultRouterWithSolana to provide a Solana RPC client.
 func NewDefaultRouter() *Router {
 	return NewRouter(
+		WithProvider(NewRelayProvider(nil)),
+		WithProvider(NewTHORChainProvider(nil)),
+		WithProvider(NewMayachainProvider(nil)),
+		WithProvider(NewLiFiProvider("")),
+		WithProvider(NewOneInchProvider("")),
+		WithProvider(NewJupiterProvider("")),
+		WithProvider(NewUniswapProvider()),
+	)
+}
+
+// NewDefaultRouterWithSolana creates a router with all default providers,
+// including Solana RPC support for Relay Solana swaps.
+func NewDefaultRouterWithSolana(solRPC *rpc.Client) *Router {
+	return NewRouter(
+		WithProvider(NewRelayProvider(solRPC)),
 		WithProvider(NewTHORChainProvider(nil)),
 		WithProvider(NewMayachainProvider(nil)),
 		WithProvider(NewLiFiProvider("")),

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -32,14 +32,14 @@ const (
 )
 
 // providerOrder defines the preferred provider order for ALL swaps.
-// Relay is tried first (solver-based, no slippage), then THORChain/Mayachain
-// for cross-chain, then DEX aggregators for same-chain swaps.
+// THORChain/Mayachain are tried first (if they support the route),
+// then Relay and LiFi as multi-chain aggregators, then DEX fallbacks.
 var providerOrder = []string{
-	ProviderRelay,     // Solver-based, no slippage, 75+ chains
-	ProviderTHORChain, // Cross-chain protocol
+	ProviderTHORChain, // Cross-chain protocol first
 	ProviderMayachain, // Alternative cross-chain
-	ProviderOneInch,   // Fallback for same-chain EVM
-	ProviderJupiter,   // Fallback for Solana
+	ProviderRelay,     // Solver-based multi-chain (before LiFi)
+	ProviderOneInch,   // Same-chain EVM
+	ProviderJupiter,   // Solana DEX
 	ProviderLiFi,      // Multi-chain aggregator
 	ProviderUniswap,   // Last resort DEX
 }

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-
-	"github.com/gagliardetto/solana-go/rpc"
 )
 
 var (
@@ -77,23 +75,10 @@ func NewRouter(opts ...RouterOption) *Router {
 	return r
 }
 
-// NewDefaultRouter creates a router with all default providers (Relay EVM-only).
+// NewDefaultRouter creates a router with all default providers
 func NewDefaultRouter() *Router {
 	return NewRouter(
 		WithProvider(NewRelayProvider(nil)),
-		WithProvider(NewTHORChainProvider(nil)),
-		WithProvider(NewMayachainProvider(nil)),
-		WithProvider(NewLiFiProvider("")),
-		WithProvider(NewOneInchProvider("")),
-		WithProvider(NewJupiterProvider("")),
-		WithProvider(NewUniswapProvider()),
-	)
-}
-
-// NewDefaultRouterWithSolana creates a router with Relay Solana support.
-func NewDefaultRouterWithSolana(solRPC *rpc.Client) *Router {
-	return NewRouter(
-		WithProvider(NewRelayProvider(solRPC)),
 		WithProvider(NewTHORChainProvider(nil)),
 		WithProvider(NewMayachainProvider(nil)),
 		WithProvider(NewLiFiProvider("")),

--- a/sdk/swap/router_test.go
+++ b/sdk/swap/router_test.go
@@ -13,8 +13,8 @@ func TestNewDefaultRouter(t *testing.T) {
 		t.Errorf("expected 7 providers, got %d", len(providers))
 	}
 
-	// Verify priority order (Relay first, then THORChain, etc.)
-	expectedOrder := []string{"Relay", "THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
+	// Verify priority order
+	expectedOrder := []string{"THORChain", "Mayachain", "Relay", "LiFi", "1inch", "Jupiter", "Uniswap"}
 	for i, name := range expectedOrder {
 		if providers[i] != name {
 			t.Errorf("expected provider %d to be %s, got %s", i, name, providers[i])
@@ -392,28 +392,25 @@ func TestUnitConversions(t *testing.T) {
 func TestSmartProviderRouting(t *testing.T) {
 	router := NewDefaultRouter()
 
-	t.Run("All swaps prefer Relay first", func(t *testing.T) {
+	t.Run("All swaps prefer THORChain first", func(t *testing.T) {
 		ordered := router.getOrderedProviders(nil)
 
 		if len(ordered) == 0 {
 			t.Fatal("expected at least one provider")
 		}
-		if ordered[0].Name() != "Relay" {
-			t.Errorf("expected first provider to be Relay, got %s", ordered[0].Name())
-		}
-		if ordered[1].Name() != "THORChain" {
-			t.Errorf("expected second provider to be THORChain, got %s", ordered[1].Name())
+		if ordered[0].Name() != "THORChain" {
+			t.Errorf("expected first provider to be THORChain, got %s", ordered[0].Name())
 		}
 	})
 
-	t.Run("Cross-chain prefers Relay then THORChain", func(t *testing.T) {
+	t.Run("Cross-chain prefers THORChain", func(t *testing.T) {
 		ordered := router.getOrderedProviders(nil)
 
 		if len(ordered) == 0 {
 			t.Fatal("expected at least one provider")
 		}
-		if ordered[0].Name() != "Relay" {
-			t.Errorf("expected first provider to be Relay for cross-chain, got %s", ordered[0].Name())
+		if ordered[0].Name() != "THORChain" {
+			t.Errorf("expected first provider to be THORChain for cross-chain, got %s", ordered[0].Name())
 		}
 	})
 

--- a/sdk/swap/router_test.go
+++ b/sdk/swap/router_test.go
@@ -9,12 +9,12 @@ func TestNewDefaultRouter(t *testing.T) {
 	router := NewDefaultRouter()
 
 	providers := router.ListProviders()
-	if len(providers) != 6 {
-		t.Errorf("expected 6 providers, got %d", len(providers))
+	if len(providers) != 7 {
+		t.Errorf("expected 7 providers, got %d", len(providers))
 	}
 
-	// Verify priority order
-	expectedOrder := []string{"THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
+	// Verify priority order (Relay first, then THORChain, etc.)
+	expectedOrder := []string{"Relay", "THORChain", "Mayachain", "LiFi", "1inch", "Jupiter", "Uniswap"}
 	for i, name := range expectedOrder {
 		if providers[i] != name {
 			t.Errorf("expected provider %d to be %s, got %s", i, name, providers[i])
@@ -392,25 +392,28 @@ func TestUnitConversions(t *testing.T) {
 func TestSmartProviderRouting(t *testing.T) {
 	router := NewDefaultRouter()
 
-	t.Run("All swaps prefer THORChain first", func(t *testing.T) {
+	t.Run("All swaps prefer Relay first", func(t *testing.T) {
 		ordered := router.getOrderedProviders(nil)
 
 		if len(ordered) == 0 {
 			t.Fatal("expected at least one provider")
 		}
-		if ordered[0].Name() != "THORChain" {
-			t.Errorf("expected first provider to be THORChain, got %s", ordered[0].Name())
+		if ordered[0].Name() != "Relay" {
+			t.Errorf("expected first provider to be Relay, got %s", ordered[0].Name())
+		}
+		if ordered[1].Name() != "THORChain" {
+			t.Errorf("expected second provider to be THORChain, got %s", ordered[1].Name())
 		}
 	})
 
-	t.Run("Cross-chain prefers THORChain", func(t *testing.T) {
+	t.Run("Cross-chain prefers Relay then THORChain", func(t *testing.T) {
 		ordered := router.getOrderedProviders(nil)
 
 		if len(ordered) == 0 {
 			t.Fatal("expected at least one provider")
 		}
-		if ordered[0].Name() != "THORChain" {
-			t.Errorf("expected first provider to be THORChain for cross-chain, got %s", ordered[0].Name())
+		if ordered[0].Name() != "Relay" {
+			t.Errorf("expected first provider to be Relay for cross-chain, got %s", ordered[0].Name())
 		}
 	})
 

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -200,25 +200,25 @@ func (s *Service) IsChainSupported(chain string) bool {
 // GetChainStatus returns the availability status of a chain for swapping.
 func (s *Service) GetChainStatus(ctx context.Context, chain string) (*ProviderStatus, error) {
 	// Try Relay first (highest priority)
-	status, err := s.router.GetProviderStatus(ctx, "Relay", chain)
+	status, err := s.router.GetProviderStatus(ctx, ProviderRelay, chain)
 	if err == nil && status.Available {
 		return status, nil
 	}
 
 	// Try THORChain (cross-chain)
-	status, err = s.router.GetProviderStatus(ctx, "THORChain", chain)
+	status, err = s.router.GetProviderStatus(ctx, ProviderTHORChain, chain)
 	if err == nil && status.Available {
 		return status, nil
 	}
 
 	// Try Mayachain
-	status, err = s.router.GetProviderStatus(ctx, "Mayachain", chain)
+	status, err = s.router.GetProviderStatus(ctx, ProviderMayachain, chain)
 	if err == nil && status.Available {
 		return status, nil
 	}
 
 	// For EVM/Solana chains, check LiFi
-	status, err = s.router.GetProviderStatus(ctx, "LiFi", chain)
+	status, err = s.router.GetProviderStatus(ctx, ProviderLiFi, chain)
 	if err == nil && status.Available {
 		return status, nil
 	}

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+
+	"github.com/gagliardetto/solana-go/rpc"
 )
 
 // Service provides a high-level swap service for applications.
@@ -14,9 +16,10 @@ type Service struct {
 }
 
 // NewService creates a new swap service with the default router.
-func NewService() *Service {
+// Optional solRPC enables Relay Solana TX assembly.
+func NewService(solRPC ...*rpc.Client) *Service {
 	return &Service{
-		router: NewDefaultRouter(),
+		router: NewDefaultRouter(solRPC...),
 	}
 }
 

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -199,8 +199,14 @@ func (s *Service) IsChainSupported(chain string) bool {
 
 // GetChainStatus returns the availability status of a chain for swapping.
 func (s *Service) GetChainStatus(ctx context.Context, chain string) (*ProviderStatus, error) {
-	// Try THORChain first (highest priority for cross-chain)
-	status, err := s.router.GetProviderStatus(ctx, "THORChain", chain)
+	// Try Relay first (highest priority)
+	status, err := s.router.GetProviderStatus(ctx, "Relay", chain)
+	if err == nil && status.Available {
+		return status, nil
+	}
+
+	// Try THORChain (cross-chain)
+	status, err = s.router.GetProviderStatus(ctx, "THORChain", chain)
 	if err == nil && status.Available {
 		return status, nil
 	}

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -199,26 +199,20 @@ func (s *Service) IsChainSupported(chain string) bool {
 
 // GetChainStatus returns the availability status of a chain for swapping.
 func (s *Service) GetChainStatus(ctx context.Context, chain string) (*ProviderStatus, error) {
-	// Try Relay first (highest priority)
-	status, err := s.router.GetProviderStatus(ctx, ProviderRelay, chain)
-	if err == nil && status.Available {
-		return status, nil
-	}
-
-	// Try THORChain (cross-chain)
-	status, err = s.router.GetProviderStatus(ctx, ProviderTHORChain, chain)
+	// Try THORChain first (highest priority for cross-chain)
+	status, err := s.router.GetProviderStatus(ctx, "THORChain", chain)
 	if err == nil && status.Available {
 		return status, nil
 	}
 
 	// Try Mayachain
-	status, err = s.router.GetProviderStatus(ctx, ProviderMayachain, chain)
+	status, err = s.router.GetProviderStatus(ctx, "Mayachain", chain)
 	if err == nil && status.Available {
 		return status, nil
 	}
 
 	// For EVM/Solana chains, check LiFi
-	status, err = s.router.GetProviderStatus(ctx, ProviderLiFi, chain)
+	status, err = s.router.GetProviderStatus(ctx, "LiFi", chain)
 	if err == nil && status.Available {
 		return status, nil
 	}

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -197,7 +197,10 @@ var EVMChains = []string{
 	"Optimism",
 	"Blast",
 	"CronosChain",
-	"ZkSync",
+	"Mantle",
+	"Sei",
+	"Zksync",
+	"ZkSync", // legacy casing
 }
 
 // IsEVMChain checks if a chain is an EVM-compatible chain

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -18,10 +18,10 @@ const (
 	PriorityTHORChain = 1
 	PriorityMayachain = 2
 	PriorityRelay     = 3
-	PriorityLiFi      = 3
-	PriorityOneInch   = 4
-	PriorityJupiter   = 5
-	PriorityUniswap   = 6
+	PriorityLiFi      = 4
+	PriorityOneInch   = 5
+	PriorityJupiter   = 6
+	PriorityUniswap   = 7
 )
 
 // ProviderPreference configures which swap providers to use and in what order.

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -15,9 +15,9 @@ type Asset struct {
 
 // Provider priority constants - lower number = higher priority
 const (
-	PriorityRelay     = 0 // Solver-based, no slippage, 75+ chains
 	PriorityTHORChain = 1
 	PriorityMayachain = 2
+	PriorityRelay     = 3 // Solver-based, no slippage, tried before LiFi
 	PriorityLiFi      = 3
 	PriorityOneInch   = 4
 	PriorityJupiter   = 5
@@ -197,10 +197,7 @@ var EVMChains = []string{
 	"Optimism",
 	"Blast",
 	"CronosChain",
-	"Mantle",
-	"Sei",
-	"Zksync",
-	"ZkSync", // legacy casing
+	"ZkSync",
 }
 
 // IsEVMChain checks if a chain is an EVM-compatible chain

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -17,7 +17,7 @@ type Asset struct {
 const (
 	PriorityTHORChain = 1
 	PriorityMayachain = 2
-	PriorityRelay     = 3 // Solver-based, no slippage, tried before LiFi
+	PriorityRelay     = 3
 	PriorityLiFi      = 3
 	PriorityOneInch   = 4
 	PriorityJupiter   = 5

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -15,6 +15,7 @@ type Asset struct {
 
 // Provider priority constants - lower number = higher priority
 const (
+	PriorityRelay     = 0 // Solver-based, no slippage, 75+ chains
 	PriorityTHORChain = 1
 	PriorityMayachain = 2
 	PriorityLiFi      = 3


### PR DESCRIPTION
Add [Relay.link](https://relay.link) as a swap provider in the recipes swap router. Relay is a solver-based cross-chain protocol - no API key, no AMM slippage.

## What changed

**New file:**
- `sdk/swap/relay.go` - `RelayProvider` implementing `SwapProvider` interface

**Modified files:**
- `sdk/swap/router.go` - Add Relay to `providerOrder` (between Mayachain and 1inch), add `NewDefaultRouterWithSolana()` constructor
- `sdk/swap/types.go` - `PriorityRelay = 3` constant
- `sdk/swap/router_test.go` - Update provider count and order assertions

## Supported chains

Ethereum, BSC, Polygon, Avalanche, Arbitrum, Optimism, Base, Mantle, Zksync, Sei, Solana

## Notes

- Solana TX assembly requires a Solana RPC client. When `solRPC` is nil (default `NewDefaultRouter()`), Solana is excluded from supported chains so the router correctly falls through to Jupiter/LiFi.
- Quote responses are cached in `ProviderData` to avoid re-fetching in `BuildTx`.
- Solver-based: `MinimumOutput == ExpectedOutput` (no AMM slippage).
- Approval spender is the swap TX destination (Relay router), not the approval TX destination (token contract).

## Testing

Tested via MCP (vultisig/mcp) with local `go.mod replace`:

```
=== EVM (ETH->USDC) ===
Provider: THORChain | Output: 1.793906

=== Solana (SOL->USDC) ===
Provider: Relay | Output: 8.348537

=== Cross-chain (ETH->Base USDC) ===
Provider: THORChain | Output: 1.795028
```

THORChain wins for chains it supports (higher priority). Relay wins for Solana (THORChain doesn't support it, Relay is before LiFi/Jupiter in order).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Relay.link as a new cross-chain swap provider, supporting EVM and Solana routes.
* **Chores**
  * Updated default provider priority/order to include the new provider.
  * Service/router updated to accept optional Solana RPC integration.
* **Tests**
  * Updated router tests to reflect the new provider set and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->