### PR TITLE
feat: migrate ninerealms endpoints to thorchain.network

### DIFF
--- a/resolver/thorchain_common.go
+++ b/resolver/thorchain_common.go
@@ -6,6 +6,8 @@ import (
 	"github.com/vultisig/vultisig-go/common"
 )
 
+const defaultTHORChainBaseURL = "https://thornode.thorchain.network"
+
 func getThorChainSymbol(chain common.Chain) (string, error) {
 	switch chain {
 	case common.Bitcoin:

--- a/resolver/thorchain_router.go
+++ b/resolver/thorchain_router.go
@@ -22,7 +22,7 @@ func NewTHORChainRouterResolver() Resolver {
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		baseURL: "https://thornode.thorchain.network",
+		baseURL: defaultTHORChainBaseURL,
 	}
 }
 

--- a/resolver/thorchain_router.go
+++ b/resolver/thorchain_router.go
@@ -22,7 +22,7 @@ func NewTHORChainRouterResolver() Resolver {
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		baseURL: "https://thornode.ninerealms.com",
+		baseURL: "https://thornode.thorchain.network",
 	}
 }
 

--- a/resolver/thorchain_vault.go
+++ b/resolver/thorchain_vault.go
@@ -33,7 +33,7 @@ func NewTHORChainVaultResolver() Resolver {
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		baseURL: "https://thornode.thorchain.network",
+		baseURL: defaultTHORChainBaseURL,
 	}
 }
 

--- a/resolver/thorchain_vault.go
+++ b/resolver/thorchain_vault.go
@@ -33,7 +33,7 @@ func NewTHORChainVaultResolver() Resolver {
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		baseURL: "https://thornode.ninerealms.com",
+		baseURL: "https://thornode.thorchain.network",
 	}
 }
 

--- a/resolver/thorchain_vault_test.go
+++ b/resolver/thorchain_vault_test.go
@@ -286,7 +286,7 @@ func TestTHORChainVaultResolver_APIConsistency(t *testing.T) {
 func queryTHORChainAPIDirect() ([]InboundAddress, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	resp, err := client.Get("https://thornode.ninerealms.com/thorchain/inbound_addresses")
+	resp, err := client.Get("https://thornode.thorchain.network/thorchain/inbound_addresses")
 	if err != nil {
 		return nil, err
 	}

--- a/resolver/thorchain_vault_test.go
+++ b/resolver/thorchain_vault_test.go
@@ -286,7 +286,7 @@ func TestTHORChainVaultResolver_APIConsistency(t *testing.T) {
 func queryTHORChainAPIDirect() ([]InboundAddress, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 
-	resp, err := client.Get("https://thornode.thorchain.network/thorchain/inbound_addresses")
+	resp, err := client.Get(defaultTHORChainBaseURL + "/thorchain/inbound_addresses")
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/cosmos/thorchain/thorchain.go
+++ b/sdk/cosmos/thorchain/thorchain.go
@@ -10,7 +10,6 @@ import (
 // THORChain mainnet endpoints (REST API)
 var MainnetEndpoints = []string{
 	"https://thornode.ninerealms.com",
-	"https://thornode.thorchain.info",
 }
 
 // THORChain stagenet endpoints

--- a/sdk/cosmos/thorchain/thorchain.go
+++ b/sdk/cosmos/thorchain/thorchain.go
@@ -9,12 +9,12 @@ import (
 
 // THORChain mainnet endpoints (REST API)
 var MainnetEndpoints = []string{
-	"https://thornode.ninerealms.com",
+	"https://thornode.thorchain.network",
 }
 
 // THORChain stagenet endpoints
 var StagenetEndpoints = []string{
-	"https://stagenet-thornode.ninerealms.com",
+	"https://chainnet-thornode.thorchain.network",
 }
 
 // SDK represents the THORChain SDK for transaction signing and broadcasting

--- a/sdk/cosmos/thorchain/thorchain.go
+++ b/sdk/cosmos/thorchain/thorchain.go
@@ -14,7 +14,7 @@ var MainnetEndpoints = []string{
 
 // THORChain stagenet endpoints
 var StagenetEndpoints = []string{
-	"https://stagenet-thornode.thorchain.network",
+	"https://stagenet-thornode.ninerealms.com",
 }
 
 // SDK represents the THORChain SDK for transaction signing and broadcasting

--- a/sdk/cosmos/thorchain/thorchain.go
+++ b/sdk/cosmos/thorchain/thorchain.go
@@ -14,7 +14,7 @@ var MainnetEndpoints = []string{
 
 // THORChain stagenet endpoints
 var StagenetEndpoints = []string{
-	"https://chainnet-thornode.thorchain.network",
+	"https://stagenet-thornode.thorchain.network",
 }
 
 // SDK represents the THORChain SDK for transaction signing and broadcasting

--- a/sdk/cosmos/thorchain/thorchain_test.go
+++ b/sdk/cosmos/thorchain/thorchain_test.go
@@ -46,7 +46,7 @@ func TestNewStagenetSDK(t *testing.T) {
 }
 
 func TestNewHTTPRPCClient(t *testing.T) {
-	endpoints := []string{"https://thornode.ninerealms.com"}
+	endpoints := []string{"https://thornode.thorchain.network"}
 	client := NewHTTPRPCClient(endpoints)
 
 	assert.NotNil(t, client)

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -85,7 +85,6 @@ var thorChainNetworks = map[string]string{
 // Default THORChain endpoints
 var defaultTHORChainEndpoints = []string{
 	"https://thornode.ninerealms.com",
-	"https://thornode.thorchain.info",
 }
 
 // THORChainProvider implements SwapProvider for THORChain

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -84,7 +84,7 @@ var thorChainNetworks = map[string]string{
 
 // Default THORChain endpoints
 var defaultTHORChainEndpoints = []string{
-	"https://thornode.ninerealms.com",
+	"https://thornode.thorchain.network",
 }
 
 // THORChainProvider implements SwapProvider for THORChain


### PR DESCRIPTION
## Summary

Stacked on top of #576 (removal of the stale/duplicate THORChain mainnet endpoint).

Nine Realms infra is being retired on April 20, 2026 (with 301 redirects going up ~2 weeks before). This migrates all `thornode.ninerealms.com` references to `thornode.thorchain.network`, consistent with what the native apps (iOS, Android, Windows) already use.

- `thornode.ninerealms.com` -> `thornode.thorchain.network` (mainnet REST API)
- `stagenet-thornode.ninerealms.com` -> `chainnet-thornode.thorchain.network` (stagenet REST API)

6 files changed across `sdk/swap/`, `sdk/cosmos/thorchain/`, and `resolver/`.

## Testing

Curled both new endpoints to confirm they're live and returning correct data:

**Mainnet:**
```
$ curl -sS "https://thornode.thorchain.network/thorchain/inbound_addresses" | tail -5
    "outbound_fee": "18809800",
    "dust_threshold": "100000000"
  }
]
HTTP 200 | 0.20s
```

**Stagenet (chainnet):**
```
$ curl -sS "https://chainnet-thornode.thorchain.network/thorchain/inbound_addresses" | tail -5
  }
]
HTTP 200 | 0.15s
```

Also tested end-to-end via MCP consuming this branch - BTC/LTC/DOGE fee rates all return correctly from `thornode.thorchain.network`.

## Risk

Low - string replacements only, no logic changes. Consistent with what iOS/Android/Windows already use in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated THORChain endpoints to the official thorchain.network hosts for mainnet and stagenet, improving reliability and service connectivity.
  * Runtime components now consistently use the configured THORChain base URL instead of a prior hardcoded host.
  * Tests adjusted to reflect the new official endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->