### PR TITLE
feat: add cetus swap provider for sui

### DIFF
--- a/sdk/swap/cetus.go
+++ b/sdk/swap/cetus.go
@@ -69,11 +69,21 @@ func (p *CetusProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 
 	fromCoinType := req.From.Address
 	if fromCoinType == "" {
+		if req.From.Symbol != "SUI" {
+			return nil, fmt.Errorf("non-SUI asset missing contract address")
+		}
 		fromCoinType = suiNativeCoinType
 	}
 	toCoinType := req.To.Address
 	if toCoinType == "" {
+		if req.To.Symbol != "SUI" {
+			return nil, fmt.Errorf("non-SUI asset missing contract address")
+		}
 		toCoinType = suiNativeCoinType
+	}
+
+	if req.Amount == nil {
+		return nil, fmt.Errorf("amount is required")
 	}
 
 	// Build route query (v param required by Cetus API)
@@ -147,18 +157,19 @@ func (p *CetusProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 	}, nil
 }
 
-// BuildTx builds an unsigned SUI transaction for the Cetus swap.
-// For now, returns the route data — the MCP layer handles SUI TX construction.
+// BuildTx returns the Cetus route data for the MCP layer to construct
+// the actual SUI Programmable Transaction Block. The PTB construction
+// requires SUI-specific tooling (shared object resolution, BCS encoding)
+// which lives in the MCP's internal/cetus package, not in this SDK.
 func (p *CetusProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResult, error) {
 	if req.Quote == nil {
 		return nil, fmt.Errorf("quote is required")
 	}
 
-	// The route data from GetQuote contains the swap instructions
-	// The MCP/app layer will construct the actual SUI transaction
 	return &SwapResult{
 		Provider:    p.Name(),
 		TxData:      req.Quote.ProviderData,
+		ToAddress:   req.Destination,
 		ExpectedOut: req.Quote.ExpectedOutput,
 	}, nil
 }

--- a/sdk/swap/cetus.go
+++ b/sdk/swap/cetus.go
@@ -1,0 +1,176 @@
+package swap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	cetusDefaultAPIURL   = "https://api-sui.cetus.zone"
+	cetusDefaultSlippage = 50 // 0.5% in bps
+	suiNativeCoinType    = "0x2::sui::SUI"
+)
+
+// Cetus only supports SUI
+var cetusSupportedChains = []string{
+	"Sui",
+}
+
+// CetusProvider implements SwapProvider for Cetus DEX aggregator on SUI.
+type CetusProvider struct {
+	BaseProvider
+	client *http.Client
+	apiURL string
+}
+
+// NewCetusProvider creates a new Cetus provider.
+func NewCetusProvider(apiURL string) *CetusProvider {
+	if apiURL == "" {
+		apiURL = cetusDefaultAPIURL
+	}
+	return &CetusProvider{
+		BaseProvider: NewBaseProvider("Cetus", PriorityCetus, cetusSupportedChains),
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		apiURL: apiURL,
+	}
+}
+
+// SupportsRoute checks if Cetus can handle a swap — SUI-to-SUI only.
+func (p *CetusProvider) SupportsRoute(from, to Asset) bool {
+	return from.Chain == "Sui" && to.Chain == "Sui"
+}
+
+// IsAvailable checks if Cetus is available for a chain.
+func (p *CetusProvider) IsAvailable(ctx context.Context, chain string) (bool, error) {
+	return chain == "Sui", nil
+}
+
+// GetStatus returns availability status.
+func (p *CetusProvider) GetStatus(ctx context.Context, chain string) (*ProviderStatus, error) {
+	return &ProviderStatus{
+		Chain:     chain,
+		Available: chain == "Sui",
+	}, nil
+}
+
+// GetQuote gets a swap quote from Cetus aggregator.
+func (p *CetusProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, error) {
+	if req.From.Chain != "Sui" || req.To.Chain != "Sui" {
+		return nil, fmt.Errorf("Cetus only supports Sui swaps")
+	}
+
+	fromCoinType := req.From.Address
+	if fromCoinType == "" {
+		fromCoinType = suiNativeCoinType
+	}
+	toCoinType := req.To.Address
+	if toCoinType == "" {
+		toCoinType = suiNativeCoinType
+	}
+
+	// Build route query (v param required by Cetus API)
+	params := url.Values{}
+	params.Set("from", fromCoinType)
+	params.Set("target", toCoinType)
+	params.Set("amount", req.Amount.String())
+	params.Set("by_amount_in", "true")
+	params.Set("v", "1010405") // SDK version required by API
+
+	routeURL := fmt.Sprintf("%s/router_v3/find_routes?%s", p.apiURL, params.Encode())
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, routeURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call Cetus API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Cetus API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var routeResp cetusRouteResponse
+	if err := json.Unmarshal(body, &routeResp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if routeResp.Code != 200 || routeResp.Data == nil {
+		msg := routeResp.Msg
+		if msg == "" {
+			msg = "no route found"
+		}
+		return nil, fmt.Errorf("Cetus routing failed: %s", msg)
+	}
+
+	outAmount := new(big.Int).SetUint64(routeResp.Data.AmountOut)
+	if outAmount.Sign() == 0 {
+		return nil, fmt.Errorf("Cetus returned zero output for this swap")
+	}
+
+	if routeResp.Data.InsufficientLiquidity {
+		return nil, fmt.Errorf("insufficient liquidity for this swap pair")
+	}
+
+	providerData, err := json.Marshal(routeResp.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal route data: %w", err)
+	}
+
+	return &Quote{
+		Provider:       p.Name(),
+		FromAsset:      req.From,
+		ToAsset:        req.To,
+		FromAmount:     req.Amount,
+		ExpectedOutput: outAmount,
+		ProviderData:   providerData,
+	}, nil
+}
+
+// BuildTx builds an unsigned SUI transaction for the Cetus swap.
+// For now, returns the route data — the MCP layer handles SUI TX construction.
+func (p *CetusProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResult, error) {
+	if req.Quote == nil {
+		return nil, fmt.Errorf("quote is required")
+	}
+
+	// The route data from GetQuote contains the swap instructions
+	// The MCP/app layer will construct the actual SUI transaction
+	return &SwapResult{
+		Provider:    p.Name(),
+		TxData:      req.Quote.ProviderData,
+		ExpectedOut: req.Quote.ExpectedOutput,
+	}, nil
+}
+
+// --- Cetus API types ---
+
+type cetusRouteResponse struct {
+	Code int             `json:"code"`
+	Msg  string          `json:"msg"`
+	Data *cetusRouteData `json:"data"`
+}
+
+type cetusRouteData struct {
+	AmountOut             uint64  `json:"amount_out"`
+	AmountIn              uint64  `json:"amount_in"`
+	InsufficientLiquidity bool    `json:"insufficient_liquidity"`
+	RequestID             string  `json:"request_id"`
+}

--- a/sdk/swap/cetus.go
+++ b/sdk/swap/cetus.go
@@ -120,7 +120,10 @@ func (p *CetusProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		return nil, fmt.Errorf("Cetus routing failed: %s", msg)
 	}
 
-	outAmount := new(big.Int).SetUint64(routeResp.Data.AmountOut)
+	outAmount, ok := new(big.Int).SetString(routeResp.Data.AmountOut.String(), 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid output amount: %s", routeResp.Data.AmountOut)
+	}
 	if outAmount.Sign() == 0 {
 		return nil, fmt.Errorf("Cetus returned zero output for this swap")
 	}
@@ -169,8 +172,8 @@ type cetusRouteResponse struct {
 }
 
 type cetusRouteData struct {
-	AmountOut             uint64  `json:"amount_out"`
-	AmountIn              uint64  `json:"amount_in"`
-	InsufficientLiquidity bool    `json:"insufficient_liquidity"`
-	RequestID             string  `json:"request_id"`
+	AmountOut             json.Number `json:"amount_out"`
+	AmountIn              json.Number `json:"amount_in"`
+	InsufficientLiquidity bool        `json:"insufficient_liquidity"`
+	RequestID             string      `json:"request_id"`
 }

--- a/sdk/swap/router.go
+++ b/sdk/swap/router.go
@@ -29,6 +29,7 @@ const (
 	ProviderOneInch   = "1inch"
 	ProviderJupiter   = "Jupiter"
 	ProviderUniswap   = "Uniswap"
+	ProviderCetus     = "Cetus"
 )
 
 // providerOrder defines the preferred provider order for ALL swaps.
@@ -42,6 +43,7 @@ var providerOrder = []string{
 	ProviderJupiter,   // Fallback for Solana
 	ProviderLiFi,      // Multi-chain aggregator
 	ProviderUniswap,   // Last resort DEX
+	ProviderCetus,     // SUI DEX aggregator
 }
 
 // Router orchestrates swap provider selection and execution
@@ -92,6 +94,7 @@ func NewDefaultRouter(solRPC ...*rpc.Client) *Router {
 		WithProvider(NewOneInchProvider("")),
 		WithProvider(NewJupiterProvider("")),
 		WithProvider(NewUniswapProvider()),
+		WithProvider(NewCetusProvider("")),
 	)
 }
 

--- a/sdk/swap/router_test.go
+++ b/sdk/swap/router_test.go
@@ -9,12 +9,12 @@ func TestNewDefaultRouter(t *testing.T) {
 	router := NewDefaultRouter()
 
 	providers := router.ListProviders()
-	if len(providers) != 7 {
-		t.Errorf("expected 7 providers, got %d", len(providers))
+	if len(providers) != 8 {
+		t.Errorf("expected 8 providers, got %d", len(providers))
 	}
 
 	// Verify priority order
-	expectedOrder := []string{"THORChain", "Mayachain", "Relay", "LiFi", "1inch", "Jupiter", "Uniswap"}
+	expectedOrder := []string{"THORChain", "Mayachain", "Relay", "LiFi", "1inch", "Jupiter", "Uniswap", "Cetus"}
 	for i, name := range expectedOrder {
 		if providers[i] != name {
 			t.Errorf("expected provider %d to be %s, got %s", i, name, providers[i])

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -22,6 +22,7 @@ const (
 	PriorityOneInch   = 5
 	PriorityJupiter   = 6
 	PriorityUniswap   = 7
+	PriorityCetus     = 8
 )
 
 // ProviderPreference configures which swap providers to use and in what order.


### PR DESCRIPTION
## Summary
- Adds Cetus swap provider for SUI-to-SUI swaps via the Cetus aggregator REST API
- Uses `api-sui.cetus.zone/router_v3/find_routes` with `v=1010405` version param
- `json.Number` for safe amount parsing (avoids float64 precision loss on large values)
- Validates non-SUI assets have contract address, validates amount is non-nil

`BuildTx` returns route data for the MCP layer to construct the actual SUI PTB (the Cetus API only provides routing, not transaction bytes).

### Dependencies
- vultisig/mcp#105 (Go PTB builder - constructs the actual SUI transaction from this provider's route data)

### On-chain proof
![SUI swap broadcast](https://files.catbox.moe/9kf9ai.png)

TX: [`AHk3LxcTHFA8cd6Q3eLs2RMqaCY2gLmazt5AwY3U8wP2`](https://suiscan.xyz/mainnet/tx/AHk3LxcTHFA8cd6Q3eLs2RMqaCY2gLmazt5AwY3U8wP2)

## Test plan
- [ ] `go build ./sdk/swap/...` passes
- [ ] `go test ./sdk/swap/...` passes
- [ ] Cetus route returned for SUI→USDC swap
- [ ] Non-SUI asset without address returns error

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cetus as a new swap provider for the Sui blockchain
  * Cetus is now integrated into the default swap routing system as a fallback option
  * Users can request swap quotes and execute transactions using the Cetus provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->