### PR TITLE
feat: add relay affiliate fees (50 bps to vultisig treasury)

### DIFF
--- a/resolver/treasury.go
+++ b/resolver/treasury.go
@@ -6,6 +6,9 @@ import (
 	"github.com/vultisig/recipes/types"
 )
 
+// DefaultEVMTreasuryAddress is the canonical Vultisig treasury address on all EVM chains.
+const DefaultEVMTreasuryAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
 type TreasuryResolver struct {
 	treasuryConfig map[string]map[string]string
 }
@@ -23,20 +26,20 @@ func NewDefaultTreasuryResolver() Resolver {
 func defaultTreasuryConfig() map[string]map[string]string {
 	return map[string]map[string]string{
 		"ethereum": {
-			"eth":     "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
-			"usdc":    "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
-			"dai":     "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
-			"weth":    "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
-			"default": "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
+			"eth":     DefaultEVMTreasuryAddress,
+			"usdc":    DefaultEVMTreasuryAddress,
+			"dai":     DefaultEVMTreasuryAddress,
+			"weth":    DefaultEVMTreasuryAddress,
+			"default": DefaultEVMTreasuryAddress,
 		},
 		"bitcoin": {
 			"btc":     "bc1qelza2cr7w92dmzgkmhdn0a4vcqpe9rfpfknr6a",
 			"default": "bc1qelza2cr7w92dmzgkmhdn0a4vcqpe9rfpfknr6a",
 		},
 		"arbitrum": {
-			"eth":     "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
-			"usdc":    "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
-			"default": "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9",
+			"eth":     DefaultEVMTreasuryAddress,
+			"usdc":    DefaultEVMTreasuryAddress,
+			"default": DefaultEVMTreasuryAddress,
 		},
 	}
 }

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -17,8 +17,10 @@ import (
 )
 
 const (
-	relayDefaultBaseURL = "https://api.relay.link"
-	relayReferrer       = "vultisig"
+	relayDefaultBaseURL   = "https://api.relay.link"
+	relayReferrer         = "vultisig"
+	relayAffiliateBps     = "50" // 0.5%
+	relayAffiliatAddress  = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
 )
 
 // Relay chain IDs
@@ -118,6 +120,10 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		TradeType:           "EXACT_INPUT",
 		Recipient:           recipient,
 		Referrer:            relayReferrer,
+		AppFees: []relayAppFee{{
+			Recipient: relayAffiliatAddress,
+			Fee:       relayAffiliateBps,
+		}},
 	}
 
 	quoteResp, err := p.postQuote(ctx, quoteReq)
@@ -420,15 +426,21 @@ func trimHexPrefix(s string) string {
 // --- Relay API types ---
 
 type relayQuoteRequest struct {
-	User                string `json:"user"`
-	OriginChainID       int    `json:"originChainId"`
-	DestinationChainID  int    `json:"destinationChainId"`
-	OriginCurrency      string `json:"originCurrency"`
-	DestinationCurrency string `json:"destinationCurrency"`
-	Amount              string `json:"amount"`
-	TradeType           string `json:"tradeType"`
-	Recipient           string `json:"recipient"`
-	Referrer            string `json:"referrer"`
+	User                string        `json:"user"`
+	OriginChainID       int           `json:"originChainId"`
+	DestinationChainID  int           `json:"destinationChainId"`
+	OriginCurrency      string        `json:"originCurrency"`
+	DestinationCurrency string        `json:"destinationCurrency"`
+	Amount              string        `json:"amount"`
+	TradeType           string        `json:"tradeType"`
+	Recipient           string        `json:"recipient"`
+	Referrer            string        `json:"referrer"`
+	AppFees             []relayAppFee `json:"appFees,omitempty"`
+}
+
+type relayAppFee struct {
+	Recipient string `json:"recipient"`
+	Fee       string `json:"fee"` // basis points
 }
 
 type relayQuoteResponse struct {

--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -14,13 +14,13 @@ import (
 	"github.com/gagliardetto/solana-go"
 	addresslookuptable "github.com/gagliardetto/solana-go/programs/address-lookup-table"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/vultisig/recipes/resolver"
 )
 
 const (
-	relayDefaultBaseURL   = "https://api.relay.link"
-	relayReferrer         = "vultisig"
-	relayAffiliateBps     = "50" // 0.5%
-	relayAffiliatAddress  = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+	relayDefaultBaseURL  = "https://api.relay.link"
+	relayReferrer        = "vultisig"
+	relayAffiliateBps    = "50" // 0.5%
 )
 
 // Relay chain IDs
@@ -121,7 +121,7 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		Recipient:           recipient,
 		Referrer:            relayReferrer,
 		AppFees: []relayAppFee{{
-			Recipient: relayAffiliatAddress,
+			Recipient: resolver.DefaultEVMTreasuryAddress,
 			Fee:       relayAffiliateBps,
 		}},
 	}


### PR DESCRIPTION
## Summary
Adds \`appFees\` to Relay swap quote requests — 0.5% (50 bps) affiliate fee directed to Vultisig treasury (\`0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9\`).

**Changes in \`relay.go\`:**
- Added \`relayAffiliateBps\` and \`relayAffiliatAddress\` constants
- Added \`AppFees []relayAppFee\` to \`relayQuoteRequest\`
- \`relayAppFee\` struct with \`Recipient\` and \`Fee\` (bps)
- Every \`GetQuote\` call now includes the appFees array

Relay requires no registration — \`appFees\` just works. Fee is deducted from swap output and settled to the recipient address.

Applies to all 11 Relay-supported chains: Ethereum, BSC, Polygon, Avalanche, Arbitrum, Optimism, Base, Mantle, zkSync, Sei, Solana.

### API verification

\`\`\`
$ curl -s relay.link/quote (with appFees 50 bps)
Output: 9939185031132742
App fee: 50000000000000 ($0.103 USD)

$ curl -s relay.link/quote (without appFees)
Output: 9989185031132742
App fee: 0 ($0 USD)

Delta: 50000000000000 = exactly 50 bps of 0.01 ETH input
\`\`\`

## Test plan
- [x] \`go build ./sdk/swap/...\` passes
- [x] Relay quote includes \`fees.app\` with non-zero amount when appFees present
- [x] fees.app.amount is zero without appFees
- [x] Output delta matches fee exactly (50 bps)
- [ ] Existing Relay swap flow unaffected (appFees is additive)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay swap quote requests now support affiliate/app fee entries, enabling inclusion of a recipient and fee for fee distribution during swaps.

* **Chores**
  * Centralized the default treasury reference used for fee routing across chains to a single canonical value to simplify configuration and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->