### PR TITLE
fix: thorchain/mayachain always-available for native receives

### DIFF
--- a/sdk/swap/mayachain.go
+++ b/sdk/swap/mayachain.go
@@ -95,6 +95,15 @@ func (p *MayachainProvider) GetStatus(ctx context.Context, chain string) (*Provi
 		}, nil
 	}
 
+	// MayaChain itself doesn't appear in inbound_addresses (native CACAO/MAYA
+	// transfers don't go through vaults). Always available for receives.
+	if network == mayaChainMAYA {
+		return &ProviderStatus{
+			Chain:     chain,
+			Available: true,
+		}, nil
+	}
+
 	addresses, err := p.getInboundAddresses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get inbound addresses: %w", err)

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -140,6 +140,15 @@ func (p *THORChainProvider) GetStatus(ctx context.Context, chain string) (*Provi
 		}, nil
 	}
 
+	// THORChain itself doesn't appear in inbound_addresses (native RUNE
+	// transfers don't go through vaults). Always available for receives.
+	if network == thorChainTHOR {
+		return &ProviderStatus{
+			Chain:     chain,
+			Available: true,
+		}, nil
+	}
+
 	addresses, err := p.getInboundAddresses(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get inbound addresses: %w", err)


### PR DESCRIPTION
## Summary
THORChain/MayaChain don't appear in their own \`inbound_addresses\` (native RUNE/CACAO transfers don't go through vaults). The \`IsAvailable\` check was failing for swaps TO THORChain/MayaChain, returning "no swap route available" even when the pool exists and is active.

Fix: return \`Available=true\` for THORChain/MayaChain native chains without checking inbound_addresses.

## Live verification
- DOGE→RUNE swap now returns quote via THORChain provider (was "no swap route available")
- Verified: 15 DOGE → ~3.53 RUNE via THORChain

![DOGE RUNE swap](https://files.catbox.moe/7s2ofu.png)

## Test plan
- [x] \`go build ./sdk/...\` clean
- [x] MCP \`build_swap_tx\` with DOGE→RUNE returns THORChain quote
- [x] THORNode inbound_addresses confirms DOGE pool active, THOR not listed (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined network status checks for MayaChain and THORChain, reducing unnecessary processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->