### PR TITLE
feat(cosmos): add MsgBeginRedelegate + MsgWithdrawDelegatorReward schemas

### DIFF
--- a/chain/cosmos/chain.go
+++ b/chain/cosmos/chain.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	tx "github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/vultisig/mobile-tss-lib/tss"
 	"github.com/vultisig/recipes/types"
 )
@@ -56,6 +58,12 @@ func NewChain(config ChainConfig) *Chain {
 
 	// Register bank message types
 	banktypes.RegisterInterfaces(ir)
+
+	// Register staking message types (MsgDelegate, MsgUndelegate, MsgBeginRedelegate, ...)
+	stakingtypes.RegisterInterfaces(ir)
+
+	// Register distribution message types (MsgWithdrawDelegatorReward, ...)
+	distributiontypes.RegisterInterfaces(ir)
 
 	// Register any extra types specific to this chain
 	if config.RegisterExtraTypes != nil {

--- a/chain/cosmos/chain.go
+++ b/chain/cosmos/chain.go
@@ -279,4 +279,3 @@ func DefaultFromExtractorWithDeposit(tx *tx.Tx, cdc codec.Codec, bech32Prefix st
 	}
 	return ""
 }
-

--- a/chain/cosmos/gaia/chain.go
+++ b/chain/cosmos/gaia/chain.go
@@ -14,14 +14,20 @@ func NewChain() *cosmos.Chain {
 		Name:         "Cosmos",
 		Description:  "Cosmos (GAIA) is the hub of the Cosmos network, enabling cross-chain communication via IBC.",
 		Bech32Prefix: "cosmos",
-		Protocols:    []string{"atom", "send"},
+		Protocols: []string{"atom", "send", "staking_redelegate", "staking_withdraw_rewards"},
 		MessageTypeRegistry: cosmos.NewMessageTypeRegistry(map[string]cosmos.MessageType{
-			cosmos.TypeUrlCosmosMsgSend: cosmos.MessageTypeSend,
+			cosmos.TypeUrlCosmosMsgSend:                    cosmos.MessageTypeSend,
+			cosmos.TypeUrlCosmosMsgBeginRedelegate:         cosmos.MessageTypeBeginRedelegate,
+			cosmos.TypeUrlCosmosMsgWithdrawDelegatorReward: cosmos.MessageTypeWithdrawDelegatorReward,
 		}),
 		GetProtocol: func(id string) (types.Protocol, error) {
 			switch id {
 			case "atom", "send":
 				return NewATOM(), nil
+			case "staking_redelegate":
+				return NewStakingRedelegate(), nil
+			case "staking_withdraw_rewards":
+				return NewStakingWithdrawRewards(), nil
 			}
 			return nil, fmt.Errorf("protocol %q not found on Cosmos", id)
 		},

--- a/chain/cosmos/gaia/chain.go
+++ b/chain/cosmos/gaia/chain.go
@@ -14,7 +14,7 @@ func NewChain() *cosmos.Chain {
 		Name:         "Cosmos",
 		Description:  "Cosmos (GAIA) is the hub of the Cosmos network, enabling cross-chain communication via IBC.",
 		Bech32Prefix: "cosmos",
-		Protocols: []string{"atom", "send", "staking_redelegate", "staking_withdraw_rewards"},
+		Protocols:    []string{"atom", "send", "staking_redelegate", "staking_withdraw_rewards"},
 		MessageTypeRegistry: cosmos.NewMessageTypeRegistry(map[string]cosmos.MessageType{
 			cosmos.TypeUrlCosmosMsgSend:                    cosmos.MessageTypeSend,
 			cosmos.TypeUrlCosmosMsgBeginRedelegate:         cosmos.MessageTypeBeginRedelegate,
@@ -33,4 +33,3 @@ func NewChain() *cosmos.Chain {
 		},
 	})
 }
-

--- a/chain/cosmos/gaia/protocol.go
+++ b/chain/cosmos/gaia/protocol.go
@@ -201,4 +201,3 @@ func (p *StakingWithdrawRewards) GetFunction(id string) (*types.Function, error)
 func (p *StakingWithdrawRewards) MatchFunctionCall(decodedTx types.DecodedTransaction, policyMatcher *types.PolicyFunctionMatcher) (bool, map[string]interface{}, error) {
 	return false, nil, fmt.Errorf("cosmos function matching is handled by the engine")
 }
-

--- a/chain/cosmos/gaia/protocol.go
+++ b/chain/cosmos/gaia/protocol.go
@@ -74,3 +74,122 @@ func (p *ATOM) MatchFunctionCall(decodedTx types.DecodedTransaction, policyMatch
 	return false, nil, fmt.Errorf("cosmos function matching is handled by the engine")
 }
 
+// StakingRedelegate implements the Cosmos Hub redelegate protocol.
+type StakingRedelegate struct {
+	id          string
+	name        string
+	description string
+	functions   []*types.Function
+}
+
+// NewStakingRedelegate creates a new StakingRedelegate protocol instance.
+func NewStakingRedelegate() *StakingRedelegate {
+	return &StakingRedelegate{
+		id:          "staking_redelegate",
+		name:        "Cosmos Staking Redelegate",
+		description: "Redelegate staked ATOM from one validator to another on the Cosmos Hub",
+		functions: []*types.Function{
+			{
+				ID:          "redelegate",
+				Name:        "Redelegate ATOM",
+				Description: "Move staked ATOM from a source validator to a destination validator",
+				Parameters: []*types.FunctionParam{
+					{Name: "delegator_address", Type: "address", Description: "The Cosmos address of the delegator"},
+					{Name: "validator_src_address", Type: "address", Description: "The source validator operator address"},
+					{Name: "validator_dst_address", Type: "address", Description: "The destination validator operator address"},
+					{Name: "amount", Type: "decimal", Description: "The amount of ATOM to redelegate (in uatom)"},
+					{Name: "denom", Type: "string", Description: "The coin denomination (e.g. uatom)"},
+				},
+			},
+		},
+	}
+}
+
+// ID returns the protocol identifier.
+func (p *StakingRedelegate) ID() string { return p.id }
+
+// Name returns the protocol name.
+func (p *StakingRedelegate) Name() string { return p.name }
+
+// ChainID returns the chain identifier.
+func (p *StakingRedelegate) ChainID() string { return "cosmos" }
+
+// Description returns the protocol description.
+func (p *StakingRedelegate) Description() string { return p.description }
+
+// Functions returns the available functions.
+func (p *StakingRedelegate) Functions() []*types.Function { return p.functions }
+
+// GetFunction retrieves a function by ID.
+func (p *StakingRedelegate) GetFunction(id string) (*types.Function, error) {
+	for _, fn := range p.functions {
+		if fn.ID == id {
+			return fn, nil
+		}
+	}
+	return nil, fmt.Errorf("function %q not found in protocol %q", id, p.id)
+}
+
+// MatchFunctionCall matches a transaction against a policy function matcher.
+func (p *StakingRedelegate) MatchFunctionCall(decodedTx types.DecodedTransaction, policyMatcher *types.PolicyFunctionMatcher) (bool, map[string]interface{}, error) {
+	return false, nil, fmt.Errorf("cosmos function matching is handled by the engine")
+}
+
+// StakingWithdrawRewards implements the Cosmos Hub withdraw delegator rewards protocol.
+type StakingWithdrawRewards struct {
+	id          string
+	name        string
+	description string
+	functions   []*types.Function
+}
+
+// NewStakingWithdrawRewards creates a new StakingWithdrawRewards protocol instance.
+func NewStakingWithdrawRewards() *StakingWithdrawRewards {
+	return &StakingWithdrawRewards{
+		id:          "staking_withdraw_rewards",
+		name:        "Cosmos Staking Withdraw Rewards",
+		description: "Withdraw staking rewards accrued from a validator on the Cosmos Hub",
+		functions: []*types.Function{
+			{
+				ID:          "withdraw_rewards",
+				Name:        "Withdraw Staking Rewards",
+				Description: "Claim accumulated ATOM staking rewards from a validator",
+				Parameters: []*types.FunctionParam{
+					{Name: "delegator_address", Type: "address", Description: "The Cosmos address of the delegator"},
+					{Name: "validator_address", Type: "address", Description: "The validator operator address to claim rewards from"},
+				},
+			},
+		},
+	}
+}
+
+// ID returns the protocol identifier.
+func (p *StakingWithdrawRewards) ID() string { return p.id }
+
+// Name returns the protocol name.
+func (p *StakingWithdrawRewards) Name() string { return p.name }
+
+// ChainID returns the chain identifier.
+func (p *StakingWithdrawRewards) ChainID() string { return "cosmos" }
+
+// Description returns the protocol description.
+func (p *StakingWithdrawRewards) Description() string { return p.description }
+
+// Functions returns the available functions.
+func (p *StakingWithdrawRewards) Functions() []*types.Function { return p.functions }
+
+// GetFunction retrieves a function by ID.
+func (p *StakingWithdrawRewards) GetFunction(id string) (*types.Function, error) {
+	for _, fn := range p.functions {
+		if fn.ID == id {
+			return fn, nil
+		}
+	}
+	return nil, fmt.Errorf("function %q not found in protocol %q", id, p.id)
+}
+
+// MatchFunctionCall matches a transaction against a policy function matcher.
+func (p *StakingWithdrawRewards) MatchFunctionCall(decodedTx types.DecodedTransaction, policyMatcher *types.PolicyFunctionMatcher) (bool, map[string]interface{}, error) {
+	return false, nil, fmt.Errorf("cosmos function matching is handled by the engine")
+}
+

--- a/chain/cosmos/gaia/protocol.go
+++ b/chain/cosmos/gaia/protocol.go
@@ -94,9 +94,14 @@ func NewStakingRedelegate() *StakingRedelegate {
 				Name:        "Redelegate ATOM",
 				Description: "Move staked ATOM from a source validator to a destination validator",
 				Parameters: []*types.FunctionParam{
-					{Name: "delegator_address", Type: "address", Description: "The Cosmos address of the delegator"},
-					{Name: "validator_src_address", Type: "address", Description: "The source validator operator address"},
-					{Name: "validator_dst_address", Type: "address", Description: "The destination validator operator address"},
+					// delegator_address carries the account (cosmos1...) HRP.
+					{Name: "delegator_address", Type: "address", Description: "The Cosmos account address of the delegator (cosmos1... prefix)"},
+					// validator_src_address and validator_dst_address MUST carry the validator
+					// operator (cosmosvaloper1...) HRP — not the delegator HRP. The engine
+					// enforces this at extraction time; rules that constrain these fields will
+					// reject any cosmos1... address.
+					{Name: "validator_src_address", Type: "address", Description: "The source validator operator address (cosmosvaloper1... prefix)"},
+					{Name: "validator_dst_address", Type: "address", Description: "The destination validator operator address (cosmosvaloper1... prefix)"},
 					{Name: "amount", Type: "decimal", Description: "The amount of ATOM to redelegate (in uatom)"},
 					{Name: "denom", Type: "string", Description: "The coin denomination (e.g. uatom)"},
 				},
@@ -155,8 +160,12 @@ func NewStakingWithdrawRewards() *StakingWithdrawRewards {
 				Name:        "Withdraw Staking Rewards",
 				Description: "Claim accumulated ATOM staking rewards from a validator",
 				Parameters: []*types.FunctionParam{
-					{Name: "delegator_address", Type: "address", Description: "The Cosmos address of the delegator"},
-					{Name: "validator_address", Type: "address", Description: "The validator operator address to claim rewards from"},
+					// delegator_address carries the account (cosmos1...) HRP.
+					{Name: "delegator_address", Type: "address", Description: "The Cosmos account address of the delegator (cosmos1... prefix)"},
+					// validator_address MUST carry the validator operator (cosmosvaloper1...)
+					// HRP — not the delegator HRP. The engine enforces this at extraction
+					// time; rules constraining this field will reject any cosmos1... address.
+					{Name: "validator_address", Type: "address", Description: "The validator operator address to claim rewards from (cosmosvaloper1... prefix)"},
 				},
 			},
 		},

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -15,6 +15,8 @@ const (
 	MessageTypeUnknown MessageType = iota - 1
 	MessageTypeSend
 	MessageTypeDeposit
+	MessageTypeBeginRedelegate
+	MessageTypeWithdrawDelegatorReward
 )
 
 // String returns string representation of MessageType
@@ -24,6 +26,10 @@ func (mt MessageType) String() string {
 		return "MsgSend"
 	case MessageTypeDeposit:
 		return "MsgDeposit"
+	case MessageTypeBeginRedelegate:
+		return "MsgBeginRedelegate"
+	case MessageTypeWithdrawDelegatorReward:
+		return "MsgWithdrawDelegatorReward"
 	default:
 		return "Unknown"
 	}
@@ -37,6 +43,12 @@ const (
 	// Custom chain-specific MsgSend/MsgDeposit TypeUrls
 	TypeUrlCustomMsgSend    = "/types.MsgSend"
 	TypeUrlCustomMsgDeposit = "/types.MsgDeposit"
+
+	// Cosmos staking module
+	TypeUrlCosmosMsgBeginRedelegate = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
+
+	// Cosmos distribution module
+	TypeUrlCosmosMsgWithdrawDelegatorReward = "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
 )
 
 // MessageTypeRegistry maps TypeUrls to MessageTypes for a chain

--- a/chain/cosmos/types.go
+++ b/chain/cosmos/types.go
@@ -136,4 +136,3 @@ func (p *ParsedCosmosTransaction) GetMemo() string {
 	}
 	return ""
 }
-

--- a/chain/cosmos/types_test.go
+++ b/chain/cosmos/types_test.go
@@ -1,0 +1,80 @@
+package cosmos
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageTypeStringForNewTypes(t *testing.T) {
+	assert.Equal(t, "MsgBeginRedelegate", MessageTypeBeginRedelegate.String())
+	assert.Equal(t, "MsgWithdrawDelegatorReward", MessageTypeWithdrawDelegatorReward.String())
+}
+
+func TestStakingDistributionTypeUrlConstants(t *testing.T) {
+	// These exact strings are what the verifier reads off Any.TypeUrl on the wire.
+	// Drift here means recipes and chain/upstream Cosmos SDK fall out of sync —
+	// pin them in a test so a rename is caught here, not at runtime.
+	assert.Equal(t,
+		"/cosmos.staking.v1beta1.MsgBeginRedelegate",
+		TypeUrlCosmosMsgBeginRedelegate,
+	)
+	assert.Equal(t,
+		"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
+		TypeUrlCosmosMsgWithdrawDelegatorReward,
+	)
+}
+
+func TestNewChainRegistersStakingAndDistributionInterfaces(t *testing.T) {
+	// Build a minimal Cosmos chain — same pattern as gaia.NewChain.
+	chain := NewChain(ChainConfig{
+		ID:           "cosmos",
+		Name:         "Cosmos",
+		Description:  "test",
+		Bech32Prefix: "cosmos",
+		Protocols:    []string{"atom"},
+		MessageTypeRegistry: NewMessageTypeRegistry(map[string]MessageType{
+			TypeUrlCosmosMsgSend:                           MessageTypeSend,
+			TypeUrlCosmosMsgBeginRedelegate:                MessageTypeBeginRedelegate,
+			TypeUrlCosmosMsgWithdrawDelegatorReward:        MessageTypeWithdrawDelegatorReward,
+		}),
+	})
+
+	t.Run("MsgBeginRedelegate round-trips through chain codec", func(t *testing.T) {
+		original := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+		any, err := codectypes.NewAnyWithValue(original)
+		require.NoError(t, err)
+
+		var decoded cosmostypes.Msg
+		err = chain.Codec().UnpackAny(any, &decoded)
+		require.NoError(t, err, "chain codec must know MsgBeginRedelegate")
+		_, ok := decoded.(*stakingtypes.MsgBeginRedelegate)
+		assert.True(t, ok, "decoded type must be *stakingtypes.MsgBeginRedelegate")
+	})
+
+	t.Run("MsgWithdrawDelegatorReward round-trips through chain codec", func(t *testing.T) {
+		original := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		}
+		any, err := codectypes.NewAnyWithValue(original)
+		require.NoError(t, err)
+
+		var decoded cosmostypes.Msg
+		err = chain.Codec().UnpackAny(any, &decoded)
+		require.NoError(t, err, "chain codec must know MsgWithdrawDelegatorReward")
+		_, ok := decoded.(*distributiontypes.MsgWithdrawDelegatorReward)
+		assert.True(t, ok, "decoded type must be *distributiontypes.MsgWithdrawDelegatorReward")
+	})
+}

--- a/chain/cosmos/types_test.go
+++ b/chain/cosmos/types_test.go
@@ -40,9 +40,9 @@ func TestNewChainRegistersStakingAndDistributionInterfaces(t *testing.T) {
 		Bech32Prefix: "cosmos",
 		Protocols:    []string{"atom"},
 		MessageTypeRegistry: NewMessageTypeRegistry(map[string]MessageType{
-			TypeUrlCosmosMsgSend:                           MessageTypeSend,
-			TypeUrlCosmosMsgBeginRedelegate:                MessageTypeBeginRedelegate,
-			TypeUrlCosmosMsgWithdrawDelegatorReward:        MessageTypeWithdrawDelegatorReward,
+			TypeUrlCosmosMsgSend:                    MessageTypeSend,
+			TypeUrlCosmosMsgBeginRedelegate:         MessageTypeBeginRedelegate,
+			TypeUrlCosmosMsgWithdrawDelegatorReward: MessageTypeWithdrawDelegatorReward,
 		}),
 	})
 

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -494,8 +494,17 @@ func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *s
 //
 // This message has no amount field — the chain pays out whatever rewards have accrued
 // from the delegator/validator pair. Policy rules can therefore only constrain by
-// delegator and validator address (e.g., validator allowlist).
+// delegator and validator address (e.g., validator allowlist), so we fail fast if
+// either is empty rather than letting an empty string flow into the constraint
+// matcher (mirrors the redelegate validator address checks).
 func (e *Engine) extractParameterFromMsgWithdrawDelegatorReward(paramName string, msg *distributiontypes.MsgWithdrawDelegatorReward) (any, error) {
+	if msg.DelegatorAddress == "" {
+		return nil, fmt.Errorf("withdraw_rewards delegator_address required")
+	}
+	if msg.ValidatorAddress == "" {
+		return nil, fmt.Errorf("withdraw_rewards validator_address required")
+	}
+
 	switch paramName {
 	case "delegator_address":
 		return msg.DelegatorAddress, nil

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -12,6 +12,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tx "github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/vultisig/recipes/chain/cosmos"
 	"github.com/vultisig/recipes/engine/compare"
@@ -55,6 +57,12 @@ func NewEngine(config Config) *Engine {
 
 	// Register bank message types
 	banktypes.RegisterInterfaces(ir)
+
+	// Register staking message types (MsgDelegate, MsgUndelegate, MsgBeginRedelegate, ...)
+	stakingtypes.RegisterInterfaces(ir)
+
+	// Register distribution message types (MsgWithdrawDelegatorReward, ...)
+	distributiontypes.RegisterInterfaces(ir)
 
 	// Register any extra types specific to this chain
 	if config.RegisterExtraTypes != nil {
@@ -207,6 +215,44 @@ func (e *Engine) unpackMsgDeposit(msg *codectypes.Any) (*types.MsgDeposit, error
 	return msgDeposit, nil
 }
 
+// unpackMsgBeginRedelegate unpacks a message to staking MsgBeginRedelegate type.
+func (e *Engine) unpackMsgBeginRedelegate(msg *codectypes.Any) (*stakingtypes.MsgBeginRedelegate, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("nil message")
+	}
+
+	var sdkMsg sdk.Msg
+	if err := e.cdc.UnpackAny(msg, &sdkMsg); err != nil {
+		return nil, fmt.Errorf("failed to unpack sdk.Msg: %w (typeUrl=%s)", err, msg.TypeUrl)
+	}
+
+	msgRedelegate, ok := sdkMsg.(*stakingtypes.MsgBeginRedelegate)
+	if !ok {
+		return nil, fmt.Errorf("expected staking MsgBeginRedelegate, got: %T", sdkMsg)
+	}
+
+	return msgRedelegate, nil
+}
+
+// unpackMsgWithdrawDelegatorReward unpacks a message to distribution MsgWithdrawDelegatorReward type.
+func (e *Engine) unpackMsgWithdrawDelegatorReward(msg *codectypes.Any) (*distributiontypes.MsgWithdrawDelegatorReward, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("nil message")
+	}
+
+	var sdkMsg sdk.Msg
+	if err := e.cdc.UnpackAny(msg, &sdkMsg); err != nil {
+		return nil, fmt.Errorf("failed to unpack sdk.Msg: %w (typeUrl=%s)", err, msg.TypeUrl)
+	}
+
+	msgWithdraw, ok := sdkMsg.(*distributiontypes.MsgWithdrawDelegatorReward)
+	if !ok {
+		return nil, fmt.Errorf("expected distribution MsgWithdrawDelegatorReward, got: %T", sdkMsg)
+	}
+
+	return msgWithdraw, nil
+}
+
 
 // validateTarget validates the transaction target against the rule target.
 func (e *Engine) validateTarget(resource *types.ResourcePath, target *types.Target, txData *tx.Tx, mt cosmos.MessageType) error {
@@ -317,6 +363,20 @@ func (e *Engine) extractParameterValue(paramName string, txData *tx.Tx, mt cosmo
 		}
 		return e.extractParameterFromMsgDeposit(paramName, msgDeposit)
 
+	case cosmos.MessageTypeBeginRedelegate:
+		msgRedelegate, err := e.unpackMsgBeginRedelegate(msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack message: %w", err)
+		}
+		return e.extractParameterFromMsgBeginRedelegate(paramName, msgRedelegate)
+
+	case cosmos.MessageTypeWithdrawDelegatorReward:
+		msgWithdraw, err := e.unpackMsgWithdrawDelegatorReward(msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack message: %w", err)
+		}
+		return e.extractParameterFromMsgWithdrawDelegatorReward(paramName, msgWithdraw)
+
 	default:
 		return nil, fmt.Errorf("unsupported message type: %s", mt)
 	}
@@ -381,6 +441,60 @@ func (e *Engine) extractParameterFromMsgDeposit(paramName string, msgDeposit *ty
 			return nil, fmt.Errorf("coin missing asset information")
 		}
 		return coin.Asset.Symbol, nil
+	default:
+		return nil, fmt.Errorf("unsupported parameter: %s", paramName)
+	}
+}
+
+// extractParameterFromMsgBeginRedelegate extracts parameters from staking MsgBeginRedelegate.
+//
+// MsgBeginRedelegate moves stake from one validator (src) to another (dst) for a given
+// delegator. We expose the addresses, the amount and the denom so that policy rules can
+// constrain redelegation by validator allowlist or amount caps. We also enforce two
+// invariants here that any healthy redelegate tx must satisfy:
+//   - amount > 0 (zero-amount redelegations are nonsensical and rejected by the chain)
+//   - validator_src_address != validator_dst_address (chain rejects, but we fail fast)
+//
+// Bech32 prefix validation for the addresses is intentionally not enforced at this layer:
+// the Cosmos SDK proto-decode will accept any string, and chain-specific prefix checks
+// belong on the per-chain engine wiring (where Bech32Prefix is known) — this generic
+// extractor mirrors how MsgSend handles ToAddress without prefix checks.
+func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *stakingtypes.MsgBeginRedelegate) (any, error) {
+	if msg.ValidatorSrcAddress != "" && msg.ValidatorSrcAddress == msg.ValidatorDstAddress {
+		return nil, fmt.Errorf("redelegate src and dst validators must differ: %s", msg.ValidatorSrcAddress)
+	}
+	if msg.Amount.Amount.IsNil() || !msg.Amount.Amount.IsPositive() {
+		return nil, fmt.Errorf("redelegate amount must be > 0")
+	}
+
+	switch paramName {
+	case "delegator_address":
+		return msg.DelegatorAddress, nil
+	case "validator_src_address":
+		return msg.ValidatorSrcAddress, nil
+	case "validator_dst_address":
+		return msg.ValidatorDstAddress, nil
+	case "amount":
+		return msg.Amount.Amount.BigInt(), nil
+	case "denom":
+		return msg.Amount.Denom, nil
+	default:
+		return nil, fmt.Errorf("unsupported parameter: %s", paramName)
+	}
+}
+
+// extractParameterFromMsgWithdrawDelegatorReward extracts parameters from
+// distribution MsgWithdrawDelegatorReward.
+//
+// This message has no amount field — the chain pays out whatever rewards have accrued
+// from the delegator/validator pair. Policy rules can therefore only constrain by
+// delegator and validator address (e.g., validator allowlist).
+func (e *Engine) extractParameterFromMsgWithdrawDelegatorReward(paramName string, msg *distributiontypes.MsgWithdrawDelegatorReward) (any, error) {
+	switch paramName {
+	case "delegator_address":
+		return msg.DelegatorAddress, nil
+	case "validator_address":
+		return msg.ValidatorAddress, nil
 	default:
 		return nil, fmt.Errorf("unsupported parameter: %s", paramName)
 	}

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -460,6 +460,9 @@ func (e *Engine) extractParameterFromMsgDeposit(paramName string, msgDeposit *ty
 // belong on the per-chain engine wiring (where Bech32Prefix is known) — this generic
 // extractor mirrors how MsgSend handles ToAddress without prefix checks.
 func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *stakingtypes.MsgBeginRedelegate) (any, error) {
+	if msg.DelegatorAddress == "" {
+		return nil, fmt.Errorf("redelegate delegator_address required")
+	}
 	if msg.ValidatorSrcAddress == "" {
 		return nil, fmt.Errorf("redelegate validator_src_address required")
 	}

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -460,7 +460,13 @@ func (e *Engine) extractParameterFromMsgDeposit(paramName string, msgDeposit *ty
 // belong on the per-chain engine wiring (where Bech32Prefix is known) — this generic
 // extractor mirrors how MsgSend handles ToAddress without prefix checks.
 func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *stakingtypes.MsgBeginRedelegate) (any, error) {
-	if msg.ValidatorSrcAddress != "" && msg.ValidatorSrcAddress == msg.ValidatorDstAddress {
+	if msg.ValidatorSrcAddress == "" {
+		return nil, fmt.Errorf("redelegate validator_src_address required")
+	}
+	if msg.ValidatorDstAddress == "" {
+		return nil, fmt.Errorf("redelegate validator_dst_address required")
+	}
+	if msg.ValidatorSrcAddress == msg.ValidatorDstAddress {
 		return nil, fmt.Errorf("redelegate src and dst validators must differ: %s", msg.ValidatorSrcAddress)
 	}
 	if msg.Amount.Amount.IsNil() || !msg.Amount.Amount.IsPositive() {

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -274,7 +274,6 @@ func (e *Engine) unpackMsgWithdrawDelegatorReward(msg *codectypes.Any) (*distrib
 	return msgWithdraw, nil
 }
 
-
 // validateTarget validates the transaction target against the rule target.
 func (e *Engine) validateTarget(resource *types.ResourcePath, target *types.Target, txData *tx.Tx, mt cosmos.MessageType) error {
 	if target == nil || target.GetTargetType() == types.TargetType_TARGET_TYPE_UNSPECIFIED {
@@ -635,4 +634,3 @@ func (e *Engine) assertArgsByType(chainId, inputName string, arg any, constraint
 func (e *Engine) ExtractTxBytes(txData string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(txData)
 }
-

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -131,6 +131,15 @@ func (e *Engine) Evaluate(rule *types.Rule, txBytes []byte) error {
 		return err
 	}
 
+	// Validate address HRPs unconditionally — before parameter constraint evaluation.
+	// This prevents a delegator (cosmos1...) address from reaching a rule that expects
+	// a validator (cosmosvaloper1...) address, regardless of whether the rule has
+	// parameter constraints. Without this eager check, a rule with no constraints
+	// (or constraints on non-address fields) would silently accept a wrong-HRP address.
+	if err := e.validateAddressHRPs(msg, mt); err != nil {
+		return err
+	}
+
 	if err := e.validateTarget(r, rule.GetTarget(), txData, mt); err != nil {
 		return fmt.Errorf("failed to validate target: %w", err)
 	}
@@ -458,6 +467,47 @@ func (e *Engine) extractParameterFromMsgDeposit(paramName string, msgDeposit *ty
 	}
 }
 
+// validateAddressHRPs performs eager HRP validation for all address fields in
+// staking/distribution messages, unconditionally — before parameter constraint
+// evaluation. This ensures a wrong-HRP address is rejected even when the rule
+// has no parameter constraints (or constraints on non-address fields), closing
+// the fail-open window identified in codex C1.
+//
+// Only staking message types carry validator addresses; other message types are
+// a no-op. Chains that leave Bech32Prefix/ValidatorBech32Prefix empty skip the
+// check (backward-compatible).
+func (e *Engine) validateAddressHRPs(msg *codectypes.Any, mt cosmos.MessageType) error {
+	switch mt {
+	case cosmos.MessageTypeBeginRedelegate:
+		msgRedelegate, err := e.unpackMsgBeginRedelegate(msg)
+		if err != nil {
+			return fmt.Errorf("failed to unpack MsgBeginRedelegate for HRP validation: %w", err)
+		}
+		if err := validateHRP(msgRedelegate.DelegatorAddress, e.config.Bech32Prefix, "delegator_address"); err != nil {
+			return err
+		}
+		if err := validateHRP(msgRedelegate.ValidatorSrcAddress, e.config.ValidatorBech32Prefix, "validator_src_address"); err != nil {
+			return err
+		}
+		if err := validateHRP(msgRedelegate.ValidatorDstAddress, e.config.ValidatorBech32Prefix, "validator_dst_address"); err != nil {
+			return err
+		}
+
+	case cosmos.MessageTypeWithdrawDelegatorReward:
+		msgWithdraw, err := e.unpackMsgWithdrawDelegatorReward(msg)
+		if err != nil {
+			return fmt.Errorf("failed to unpack MsgWithdrawDelegatorReward for HRP validation: %w", err)
+		}
+		if err := validateHRP(msgWithdraw.DelegatorAddress, e.config.Bech32Prefix, "delegator_address"); err != nil {
+			return err
+		}
+		if err := validateHRP(msgWithdraw.ValidatorAddress, e.config.ValidatorBech32Prefix, "validator_address"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateHRP decodes addr as bech32 and verifies its human-readable part equals
 // wantPrefix. Returns a descriptive error on mismatch or decode failure.
 // If wantPrefix is empty the check is skipped (chains that don't set a prefix).
@@ -480,14 +530,12 @@ func validateHRP(addr, wantPrefix, fieldName string) error {
 //
 // MsgBeginRedelegate moves stake from one validator (src) to another (dst) for a given
 // delegator. We expose the addresses, the amount and the denom so that policy rules can
-// constrain redelegation by validator allowlist or amount caps. We enforce three invariants:
+// constrain redelegation by validator allowlist or amount caps. We enforce two invariants:
 //   - amount > 0 (zero-amount redelegations are nonsensical and rejected by the chain)
 //   - validator_src_address != validator_dst_address (chain rejects, but we fail fast)
-//   - HRP of each address matches the expected Bech32 prefix for its role: delegator
-//     addresses must carry Bech32Prefix (e.g. "cosmos"), validator addresses must carry
-//     ValidatorBech32Prefix (e.g. "cosmosvaloper"). Without this check a rule constraining
-//     validator_src_address to a cosmosvaloper1... value would silently accept a cosmos1...
-//     delegator address — a fail-open bypass.
+//
+// HRP validation for the address fields is performed earlier in validateAddressHRPs,
+// called unconditionally from Evaluate before this extractor is ever reached.
 func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *stakingtypes.MsgBeginRedelegate) (any, error) {
 	if msg.DelegatorAddress == "" {
 		return nil, fmt.Errorf("redelegate delegator_address required")
@@ -503,20 +551,6 @@ func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *s
 	}
 	if msg.Amount.Amount.IsNil() || !msg.Amount.Amount.IsPositive() {
 		return nil, fmt.Errorf("redelegate amount must be > 0")
-	}
-
-	// HRP validation: enforce that each address carries the correct bech32 prefix
-	// for its role. This prevents a cosmos1... delegator address from being accepted
-	// in a validator field (and vice versa), which would otherwise be a fail-open
-	// bypass for rules that constrain validator addresses.
-	if err := validateHRP(msg.DelegatorAddress, e.config.Bech32Prefix, "delegator_address"); err != nil {
-		return nil, err
-	}
-	if err := validateHRP(msg.ValidatorSrcAddress, e.config.ValidatorBech32Prefix, "validator_src_address"); err != nil {
-		return nil, err
-	}
-	if err := validateHRP(msg.ValidatorDstAddress, e.config.ValidatorBech32Prefix, "validator_dst_address"); err != nil {
-		return nil, err
 	}
 
 	switch paramName {
@@ -542,25 +576,16 @@ func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *s
 // from the delegator/validator pair. Policy rules can therefore only constrain by
 // delegator and validator address (e.g., validator allowlist), so we fail fast if
 // either is empty rather than letting an empty string flow into the constraint
-// matcher (mirrors the redelegate validator address checks).
+// matcher.
 //
-// HRP validation is applied for the same reason as in extractParameterFromMsgBeginRedelegate:
-// a rule constraining validator_address to cosmosvaloper1... must not silently accept
-// cosmos1... — that would be a fail-open bypass.
+// HRP validation for address fields is performed earlier in validateAddressHRPs,
+// called unconditionally from Evaluate before this extractor is ever reached.
 func (e *Engine) extractParameterFromMsgWithdrawDelegatorReward(paramName string, msg *distributiontypes.MsgWithdrawDelegatorReward) (any, error) {
 	if msg.DelegatorAddress == "" {
 		return nil, fmt.Errorf("withdraw_rewards delegator_address required")
 	}
 	if msg.ValidatorAddress == "" {
 		return nil, fmt.Errorf("withdraw_rewards validator_address required")
-	}
-
-	// HRP validation: same fail-open protection as in extractParameterFromMsgBeginRedelegate.
-	if err := validateHRP(msg.DelegatorAddress, e.config.Bech32Prefix, "delegator_address"); err != nil {
-		return nil, err
-	}
-	if err := validateHRP(msg.ValidatorAddress, e.config.ValidatorBech32Prefix, "validator_address"); err != nil {
-		return nil, err
 	}
 
 	switch paramName {

--- a/engine/cosmos/cosmos.go
+++ b/engine/cosmos/cosmos.go
@@ -10,6 +10,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
 	tx "github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -40,6 +41,17 @@ type Config struct {
 
 	// RegisterExtraTypes is an optional function to register additional protobuf types
 	RegisterExtraTypes func(ir codectypes.InterfaceRegistry)
+
+	// Bech32Prefix is the account address prefix (e.g., "cosmos", "maya", "thor").
+	// When non-empty, delegator address fields are validated to carry this HRP.
+	Bech32Prefix string
+
+	// ValidatorBech32Prefix is the validator operator address prefix
+	// (e.g., "cosmosvaloper"). Per Cosmos SDK convention this is always
+	// Bech32Prefix+"valoper". When non-empty, validator address fields are
+	// validated to carry this HRP, preventing a delegator address from being
+	// silently accepted in a validator field (fail-open attack).
+	ValidatorBech32Prefix string
 }
 
 // Engine is a generic Cosmos engine that can be configured for different chains.
@@ -446,19 +458,36 @@ func (e *Engine) extractParameterFromMsgDeposit(paramName string, msgDeposit *ty
 	}
 }
 
+// validateHRP decodes addr as bech32 and verifies its human-readable part equals
+// wantPrefix. Returns a descriptive error on mismatch or decode failure.
+// If wantPrefix is empty the check is skipped (chains that don't set a prefix).
+func validateHRP(addr, wantPrefix, fieldName string) error {
+	if wantPrefix == "" {
+		return nil
+	}
+	hrp, _, err := bech32.DecodeAndConvert(addr)
+	if err != nil {
+		return fmt.Errorf("invalid bech32 address in %s %q: %w", fieldName, addr, err)
+	}
+	if hrp != wantPrefix {
+		return fmt.Errorf("invalid %s HRP: expected %q, got %q (address %s)",
+			fieldName, wantPrefix, hrp, addr)
+	}
+	return nil
+}
+
 // extractParameterFromMsgBeginRedelegate extracts parameters from staking MsgBeginRedelegate.
 //
 // MsgBeginRedelegate moves stake from one validator (src) to another (dst) for a given
 // delegator. We expose the addresses, the amount and the denom so that policy rules can
-// constrain redelegation by validator allowlist or amount caps. We also enforce two
-// invariants here that any healthy redelegate tx must satisfy:
+// constrain redelegation by validator allowlist or amount caps. We enforce three invariants:
 //   - amount > 0 (zero-amount redelegations are nonsensical and rejected by the chain)
 //   - validator_src_address != validator_dst_address (chain rejects, but we fail fast)
-//
-// Bech32 prefix validation for the addresses is intentionally not enforced at this layer:
-// the Cosmos SDK proto-decode will accept any string, and chain-specific prefix checks
-// belong on the per-chain engine wiring (where Bech32Prefix is known) — this generic
-// extractor mirrors how MsgSend handles ToAddress without prefix checks.
+//   - HRP of each address matches the expected Bech32 prefix for its role: delegator
+//     addresses must carry Bech32Prefix (e.g. "cosmos"), validator addresses must carry
+//     ValidatorBech32Prefix (e.g. "cosmosvaloper"). Without this check a rule constraining
+//     validator_src_address to a cosmosvaloper1... value would silently accept a cosmos1...
+//     delegator address — a fail-open bypass.
 func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *stakingtypes.MsgBeginRedelegate) (any, error) {
 	if msg.DelegatorAddress == "" {
 		return nil, fmt.Errorf("redelegate delegator_address required")
@@ -474,6 +503,20 @@ func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *s
 	}
 	if msg.Amount.Amount.IsNil() || !msg.Amount.Amount.IsPositive() {
 		return nil, fmt.Errorf("redelegate amount must be > 0")
+	}
+
+	// HRP validation: enforce that each address carries the correct bech32 prefix
+	// for its role. This prevents a cosmos1... delegator address from being accepted
+	// in a validator field (and vice versa), which would otherwise be a fail-open
+	// bypass for rules that constrain validator addresses.
+	if err := validateHRP(msg.DelegatorAddress, e.config.Bech32Prefix, "delegator_address"); err != nil {
+		return nil, err
+	}
+	if err := validateHRP(msg.ValidatorSrcAddress, e.config.ValidatorBech32Prefix, "validator_src_address"); err != nil {
+		return nil, err
+	}
+	if err := validateHRP(msg.ValidatorDstAddress, e.config.ValidatorBech32Prefix, "validator_dst_address"); err != nil {
+		return nil, err
 	}
 
 	switch paramName {
@@ -500,12 +543,24 @@ func (e *Engine) extractParameterFromMsgBeginRedelegate(paramName string, msg *s
 // delegator and validator address (e.g., validator allowlist), so we fail fast if
 // either is empty rather than letting an empty string flow into the constraint
 // matcher (mirrors the redelegate validator address checks).
+//
+// HRP validation is applied for the same reason as in extractParameterFromMsgBeginRedelegate:
+// a rule constraining validator_address to cosmosvaloper1... must not silently accept
+// cosmos1... — that would be a fail-open bypass.
 func (e *Engine) extractParameterFromMsgWithdrawDelegatorReward(paramName string, msg *distributiontypes.MsgWithdrawDelegatorReward) (any, error) {
 	if msg.DelegatorAddress == "" {
 		return nil, fmt.Errorf("withdraw_rewards delegator_address required")
 	}
 	if msg.ValidatorAddress == "" {
 		return nil, fmt.Errorf("withdraw_rewards validator_address required")
+	}
+
+	// HRP validation: same fail-open protection as in extractParameterFromMsgBeginRedelegate.
+	if err := validateHRP(msg.DelegatorAddress, e.config.Bech32Prefix, "delegator_address"); err != nil {
+		return nil, err
+	}
+	if err := validateHRP(msg.ValidatorAddress, e.config.ValidatorBech32Prefix, "validator_address"); err != nil {
+		return nil, err
 	}
 
 	switch paramName {

--- a/engine/cosmos/cosmos_test.go
+++ b/engine/cosmos/cosmos_test.go
@@ -1,0 +1,300 @@
+package cosmos
+
+import (
+	"math/big"
+	"testing"
+
+	"cosmossdk.io/math"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vultisig/vultisig-go/common"
+
+	"github.com/vultisig/recipes/chain/cosmos"
+)
+
+// newTestEngine creates a generic Cosmos engine wired for staking + distribution
+// in addition to the default bank MsgSend mappings.
+func newTestEngine() *Engine {
+	return NewEngine(Config{
+		ChainID:         "cosmos",
+		SupportedChains: []common.Chain{common.GaiaChain},
+		MessageTypeRegistry: cosmos.NewMessageTypeRegistry(map[string]cosmos.MessageType{
+			cosmos.TypeUrlCosmosMsgSend:                     cosmos.MessageTypeSend,
+			cosmos.TypeUrlCosmosMsgBeginRedelegate:          cosmos.MessageTypeBeginRedelegate,
+			cosmos.TypeUrlCosmosMsgWithdrawDelegatorReward:  cosmos.MessageTypeWithdrawDelegatorReward,
+		}),
+		ProtocolMessageTypes: map[string]cosmos.MessageType{
+			"atom":                       cosmos.MessageTypeSend,
+			"staking_redelegate":         cosmos.MessageTypeBeginRedelegate,
+			"staking_withdraw_rewards":   cosmos.MessageTypeWithdrawDelegatorReward,
+		},
+	})
+}
+
+// packAny wraps a sdk message into an Any using the engine's codec, exercising the
+// real interface registry that the engine builds in NewEngine.
+func packAny(t *testing.T, e *Engine, msg cosmostypes.Msg) *codectypes.Any {
+	t.Helper()
+	any, err := codectypes.NewAnyWithValue(msg)
+	require.NoError(t, err)
+	// Round-trip through the engine codec to confirm the registry knows the type.
+	require.NoError(t, e.cdc.UnpackAny(any, new(cosmostypes.Msg)))
+	return any
+}
+
+func TestExtractParameterFromMsgBeginRedelegate(t *testing.T) {
+	e := newTestEngine()
+
+	t.Run("happy path returns all params", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		got, err := e.extractParameterFromMsgBeginRedelegate("delegator_address", msg)
+		require.NoError(t, err)
+		assert.Equal(t, msg.DelegatorAddress, got)
+
+		got, err = e.extractParameterFromMsgBeginRedelegate("validator_src_address", msg)
+		require.NoError(t, err)
+		assert.Equal(t, msg.ValidatorSrcAddress, got)
+
+		got, err = e.extractParameterFromMsgBeginRedelegate("validator_dst_address", msg)
+		require.NoError(t, err)
+		assert.Equal(t, msg.ValidatorDstAddress, got)
+
+		got, err = e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(1_000_000), got)
+
+		got, err = e.extractParameterFromMsgBeginRedelegate("denom", msg)
+		require.NoError(t, err)
+		assert.Equal(t, "uatom", got)
+	})
+
+	t.Run("rejects same src and dst validator", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1samexxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1samexxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "src and dst validators must differ")
+	})
+
+	t.Run("rejects zero amount", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(0)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "amount must be > 0")
+	})
+
+	t.Run("rejects negative amount", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.Coin{Denom: "uatom", Amount: math.NewInt(-1)},
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "amount must be > 0")
+	})
+
+	t.Run("rejects unknown parameter", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("memo", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported parameter")
+	})
+}
+
+func TestExtractParameterFromMsgWithdrawDelegatorReward(t *testing.T) {
+	e := newTestEngine()
+
+	t.Run("happy path returns delegator + validator", func(t *testing.T) {
+		msg := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		}
+
+		got, err := e.extractParameterFromMsgWithdrawDelegatorReward("delegator_address", msg)
+		require.NoError(t, err)
+		assert.Equal(t, msg.DelegatorAddress, got)
+
+		got, err = e.extractParameterFromMsgWithdrawDelegatorReward("validator_address", msg)
+		require.NoError(t, err)
+		assert.Equal(t, msg.ValidatorAddress, got)
+	})
+
+	t.Run("rejects unknown parameter", func(t *testing.T) {
+		msg := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		}
+
+		_, err := e.extractParameterFromMsgWithdrawDelegatorReward("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported parameter")
+	})
+}
+
+func TestUnpackMsgBeginRedelegate(t *testing.T) {
+	e := newTestEngine()
+
+	t.Run("unpacks a real Any wrapped MsgBeginRedelegate", func(t *testing.T) {
+		original := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+		any := packAny(t, e, original)
+		assert.Equal(t, cosmos.TypeUrlCosmosMsgBeginRedelegate, any.TypeUrl,
+			"TypeUrl should match the canonical Cosmos SDK staking module url")
+
+		got, err := e.unpackMsgBeginRedelegate(any)
+		require.NoError(t, err)
+		assert.Equal(t, original.DelegatorAddress, got.DelegatorAddress)
+		assert.Equal(t, original.ValidatorSrcAddress, got.ValidatorSrcAddress)
+		assert.Equal(t, original.ValidatorDstAddress, got.ValidatorDstAddress)
+		assert.Equal(t, original.Amount.Denom, got.Amount.Denom)
+		assert.True(t, original.Amount.Amount.Equal(got.Amount.Amount))
+	})
+
+	t.Run("rejects nil message", func(t *testing.T) {
+		_, err := e.unpackMsgBeginRedelegate(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects wrong message type", func(t *testing.T) {
+		wrong := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1xxx",
+			ValidatorAddress: "cosmosvaloper1xxx",
+		}
+		any := packAny(t, e, wrong)
+		_, err := e.unpackMsgBeginRedelegate(any)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected staking MsgBeginRedelegate")
+	})
+}
+
+func TestUnpackMsgWithdrawDelegatorReward(t *testing.T) {
+	e := newTestEngine()
+
+	t.Run("unpacks a real Any wrapped MsgWithdrawDelegatorReward", func(t *testing.T) {
+		original := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		}
+		any := packAny(t, e, original)
+		assert.Equal(t, cosmos.TypeUrlCosmosMsgWithdrawDelegatorReward, any.TypeUrl,
+			"TypeUrl should match the canonical Cosmos SDK distribution module url")
+
+		got, err := e.unpackMsgWithdrawDelegatorReward(any)
+		require.NoError(t, err)
+		assert.Equal(t, original.DelegatorAddress, got.DelegatorAddress)
+		assert.Equal(t, original.ValidatorAddress, got.ValidatorAddress)
+	})
+
+	t.Run("rejects nil message", func(t *testing.T) {
+		_, err := e.unpackMsgWithdrawDelegatorReward(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects wrong message type", func(t *testing.T) {
+		wrong := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1xxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1)),
+		}
+		any := packAny(t, e, wrong)
+		_, err := e.unpackMsgWithdrawDelegatorReward(any)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected distribution MsgWithdrawDelegatorReward")
+	})
+}
+
+func TestDetectMessageTypeForStakingAndDistribution(t *testing.T) {
+	e := newTestEngine()
+
+	t.Run("MsgBeginRedelegate", func(t *testing.T) {
+		any := packAny(t, e, &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1)),
+		})
+		mt, err := e.detectMessageType(any)
+		require.NoError(t, err)
+		assert.Equal(t, cosmos.MessageTypeBeginRedelegate, mt)
+	})
+
+	t.Run("MsgWithdrawDelegatorReward", func(t *testing.T) {
+		any := packAny(t, e, &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1xxx",
+			ValidatorAddress: "cosmosvaloper1xxx",
+		})
+		mt, err := e.detectMessageType(any)
+		require.NoError(t, err)
+		assert.Equal(t, cosmos.MessageTypeWithdrawDelegatorReward, mt)
+	})
+}
+
+// TestExtractParameterValueDispatchesToNewMsgTypes confirms the public dispatch
+// path picks up the new message types — this is the single biggest behavior gap
+// the schemas close: without this, the verifier engine had no way to read params
+// off a redelegate / withdraw_rewards tx.
+func TestExtractParameterValueDispatchesToNewMsgTypes(t *testing.T) {
+	e := newTestEngine()
+
+	t.Run("MsgBeginRedelegate routes through new extractor", func(t *testing.T) {
+		any := packAny(t, e, &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(2_500_000)),
+		})
+		txData := &tx.Tx{Body: &tx.TxBody{Messages: []*codectypes.Any{any}}}
+
+		got, err := e.extractParameterValue("amount", txData, cosmos.MessageTypeBeginRedelegate)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(2_500_000), got)
+	})
+
+	t.Run("MsgWithdrawDelegatorReward routes through new extractor", func(t *testing.T) {
+		any := packAny(t, e, &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		})
+		txData := &tx.Tx{Body: &tx.TxBody{Messages: []*codectypes.Any{any}}}
+
+		got, err := e.extractParameterValue("validator_address", txData, cosmos.MessageTypeWithdrawDelegatorReward)
+		require.NoError(t, err)
+		assert.Equal(t, "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", got)
+	})
+}

--- a/engine/cosmos/cosmos_test.go
+++ b/engine/cosmos/cosmos_test.go
@@ -92,6 +92,48 @@ func TestExtractParameterFromMsgBeginRedelegate(t *testing.T) {
 		assert.Contains(t, err.Error(), "src and dst validators must differ")
 	})
 
+	// Regression: previously the equality check was guarded by `Src != ""`, which let
+	// a fully empty pair ("" == "") slip past validation. Both empty addresses must
+	// each be rejected on their own, before the equality comparison runs.
+	t.Run("rejects both empty validator addresses", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "",
+			ValidatorDstAddress: "",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validator_src_address required")
+	})
+
+	t.Run("rejects empty src validator address", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validator_src_address required")
+	})
+
+	t.Run("rejects empty dst validator address", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("amount", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validator_dst_address required")
+	})
+
 	t.Run("rejects zero amount", func(t *testing.T) {
 		msg := &stakingtypes.MsgBeginRedelegate{
 			DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

--- a/engine/cosmos/cosmos_test.go
+++ b/engine/cosmos/cosmos_test.go
@@ -202,6 +202,42 @@ func TestExtractParameterFromMsgWithdrawDelegatorReward(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported parameter")
 	})
+
+	// Regression: empty addresses must be rejected before the parameter switch
+	// runs, mirroring the redelegate validator-address checks. Without these
+	// guards, a policy match could silently succeed against an empty string.
+	t.Run("rejects empty delegator address", func(t *testing.T) {
+		msg := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "",
+			ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		}
+
+		_, err := e.extractParameterFromMsgWithdrawDelegatorReward("delegator_address", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delegator_address required")
+	})
+
+	t.Run("rejects empty validator address", func(t *testing.T) {
+		msg := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorAddress: "",
+		}
+
+		_, err := e.extractParameterFromMsgWithdrawDelegatorReward("validator_address", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validator_address required")
+	})
+
+	t.Run("rejects both empty addresses", func(t *testing.T) {
+		msg := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: "",
+			ValidatorAddress: "",
+		}
+
+		_, err := e.extractParameterFromMsgWithdrawDelegatorReward("delegator_address", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delegator_address required")
+	})
 }
 
 func TestUnpackMsgBeginRedelegate(t *testing.T) {

--- a/engine/cosmos/cosmos_test.go
+++ b/engine/cosmos/cosmos_test.go
@@ -92,6 +92,24 @@ func TestExtractParameterFromMsgBeginRedelegate(t *testing.T) {
 		assert.Contains(t, err.Error(), "src and dst validators must differ")
 	})
 
+	// CR companion to the withdraw fix already shipped (1d5f4ac):
+	// without the delegator_address required-field check, a malformed
+	// redelegate payload with an empty delegator slips past extraction
+	// when policy rules don't constrain delegator. Mirrors the
+	// withdraw_rewards / staking validator early-rejects above.
+	t.Run("rejects empty delegator address", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    "",
+			ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+
+		_, err := e.extractParameterFromMsgBeginRedelegate("delegator_address", msg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delegator_address required")
+	})
+
 	// Regression: previously the equality check was guarded by `Src != ""`, which let
 	// a fully empty pair ("" == "") slip past validation. Both empty addresses must
 	// each be rejected on their own, before the equality comparison runs.

--- a/engine/cosmos/cosmos_test.go
+++ b/engine/cosmos/cosmos_test.go
@@ -24,14 +24,14 @@ func newTestEngine() *Engine {
 		ChainID:         "cosmos",
 		SupportedChains: []common.Chain{common.GaiaChain},
 		MessageTypeRegistry: cosmos.NewMessageTypeRegistry(map[string]cosmos.MessageType{
-			cosmos.TypeUrlCosmosMsgSend:                     cosmos.MessageTypeSend,
-			cosmos.TypeUrlCosmosMsgBeginRedelegate:          cosmos.MessageTypeBeginRedelegate,
-			cosmos.TypeUrlCosmosMsgWithdrawDelegatorReward:  cosmos.MessageTypeWithdrawDelegatorReward,
+			cosmos.TypeUrlCosmosMsgSend:                    cosmos.MessageTypeSend,
+			cosmos.TypeUrlCosmosMsgBeginRedelegate:         cosmos.MessageTypeBeginRedelegate,
+			cosmos.TypeUrlCosmosMsgWithdrawDelegatorReward: cosmos.MessageTypeWithdrawDelegatorReward,
 		}),
 		ProtocolMessageTypes: map[string]cosmos.MessageType{
-			"atom":                       cosmos.MessageTypeSend,
-			"staking_redelegate":         cosmos.MessageTypeBeginRedelegate,
-			"staking_withdraw_rewards":   cosmos.MessageTypeWithdrawDelegatorReward,
+			"atom":                     cosmos.MessageTypeSend,
+			"staking_redelegate":       cosmos.MessageTypeBeginRedelegate,
+			"staking_withdraw_rewards": cosmos.MessageTypeWithdrawDelegatorReward,
 		},
 	})
 }

--- a/engine/cosmos/gaia/gaia.go
+++ b/engine/cosmos/gaia/gaia.go
@@ -19,11 +19,15 @@ func NewGaia() *Gaia {
 			ChainID:         "cosmos",
 			SupportedChains: []common.Chain{common.GaiaChain},
 			MessageTypeRegistry: cosmos.NewMessageTypeRegistry(map[string]cosmos.MessageType{
-				cosmos.TypeUrlCosmosMsgSend: cosmos.MessageTypeSend,
+				cosmos.TypeUrlCosmosMsgSend:                    cosmos.MessageTypeSend,
+				cosmos.TypeUrlCosmosMsgBeginRedelegate:         cosmos.MessageTypeBeginRedelegate,
+				cosmos.TypeUrlCosmosMsgWithdrawDelegatorReward: cosmos.MessageTypeWithdrawDelegatorReward,
 			}),
 			ProtocolMessageTypes: map[string]cosmos.MessageType{
-				"atom": cosmos.MessageTypeSend,
-				"send": cosmos.MessageTypeSend,
+				"atom":                     cosmos.MessageTypeSend,
+				"send":                     cosmos.MessageTypeSend,
+				"staking_redelegate":       cosmos.MessageTypeBeginRedelegate,
+				"staking_withdraw_rewards": cosmos.MessageTypeWithdrawDelegatorReward,
 			},
 		}),
 	}

--- a/engine/cosmos/gaia/gaia.go
+++ b/engine/cosmos/gaia/gaia.go
@@ -53,4 +53,3 @@ func (g *Gaia) Evaluate(rule *types.Rule, txBytes []byte) error {
 func (g *Gaia) ExtractTxBytes(txData string) ([]byte, error) {
 	return g.engine.ExtractTxBytes(txData)
 }
-

--- a/engine/cosmos/gaia/gaia.go
+++ b/engine/cosmos/gaia/gaia.go
@@ -29,6 +29,12 @@ func NewGaia() *Gaia {
 				"staking_redelegate":       cosmos.MessageTypeBeginRedelegate,
 				"staking_withdraw_rewards": cosmos.MessageTypeWithdrawDelegatorReward,
 			},
+			// Cosmos Hub uses "cosmos" for account addresses and "cosmosvaloper" for
+			// validator operator addresses (Cosmos SDK convention: <prefix>valoper).
+			// These are enforced by the engine to prevent a delegator address from
+			// being silently accepted in a validator field (fail-open bypass, codex C1).
+			Bech32Prefix:          "cosmos",
+			ValidatorBech32Prefix: "cosmosvaloper",
 		}),
 	}
 }

--- a/engine/cosmos/gaia/gaia_test.go
+++ b/engine/cosmos/gaia/gaia_test.go
@@ -1,6 +1,7 @@
 package gaia_test
 
 import (
+	"strings"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -17,6 +18,25 @@ import (
 
 	"github.com/vultisig/recipes/engine/cosmos/gaia"
 	"github.com/vultisig/recipes/types"
+)
+
+// Valid bech32 test addresses (deterministic, not real keys).
+// Generated with bech32.ConvertAndEncode over fixed 20-byte payloads.
+const (
+	// Account (delegator) addresses — HRP "cosmos".
+	testDelegator1 = "cosmos1uzqrd7nsnmvwjflffw48gs6u8a3n5ugrvs2dlk"
+	testDelegator2 = "cosmos1e5mzm3769s7ksr64lw4533yc88sgne68gt3nuy"
+
+	// Validator operator addresses — HRP "cosmosvaloper".
+	testValSrc = "cosmosvaloper14dpelgwgj5pnhkqwf05sgeqdjas52k2qqsptjp"
+	testValDst = "cosmosvaloper18w90vkkuhm2a39m8u63uh6c89kj00v6ukg4jqc"
+	testValAbc = "cosmosvaloper1mn7wzsk6h3aqcxeuyl9vye4w08rnnstnmk4j66"
+
+	// Wrong-HRP addresses used in negative tests.
+	// These are valid bech32 but carry the wrong prefix for the field they are
+	// placed in — proving that the extractor rejects them.
+	testAccountAsValidator  = "cosmos1gvll0hewp46cvm8wm6hqysyh2cve38j5k7npf7"   // "cosmos" HRP where "cosmosvaloper" is required
+	testValidatorAsDelegator = "cosmosvaloper1d8dg727hwgyqq6h34nwysvsm3fqkvcs3fvndue" // "cosmosvaloper" HRP where "cosmos" is required
 )
 
 // buildTestCodec creates a codec that can pack Any messages for test tx construction.
@@ -51,9 +71,9 @@ func TestNewGaia_MsgBeginRedelegate_Dispatch(t *testing.T) {
 	cdc := buildTestCodec()
 
 	msg := &stakingtypes.MsgBeginRedelegate{
-		DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		DelegatorAddress:    testDelegator1,
+		ValidatorSrcAddress: testValSrc,
+		ValidatorDstAddress: testValDst,
 		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
 	}
 	txBytes := marshalTx(t, cdc, msg)
@@ -77,8 +97,8 @@ func TestNewGaia_MsgWithdrawDelegatorReward_Dispatch(t *testing.T) {
 	cdc := buildTestCodec()
 
 	msg := &distributiontypes.MsgWithdrawDelegatorReward{
-		DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		DelegatorAddress: testDelegator1,
+		ValidatorAddress: testValAbc,
 	}
 	txBytes := marshalTx(t, cdc, msg)
 
@@ -98,12 +118,10 @@ func TestNewGaia_MsgBeginRedelegate_WithConstraint(t *testing.T) {
 	g := gaia.NewGaia()
 	cdc := buildTestCodec()
 
-	const dstValidator = "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
 	msg := &stakingtypes.MsgBeginRedelegate{
-		DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ValidatorDstAddress: dstValidator,
+		DelegatorAddress:    testDelegator1,
+		ValidatorSrcAddress: testValSrc,
+		ValidatorDstAddress: testValDst,
 		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(500_000)),
 	}
 	txBytes := marshalTx(t, cdc, msg)
@@ -117,7 +135,7 @@ func TestNewGaia_MsgBeginRedelegate_WithConstraint(t *testing.T) {
 				Constraint: &types.Constraint{
 					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
 					Value: &types.Constraint_FixedValue{
-						FixedValue: dstValidator,
+						FixedValue: testValDst,
 					},
 				},
 			},
@@ -134,11 +152,9 @@ func TestNewGaia_MsgWithdrawDelegatorReward_WithConstraint(t *testing.T) {
 	g := gaia.NewGaia()
 	cdc := buildTestCodec()
 
-	const valAddr = "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
 	msg := &distributiontypes.MsgWithdrawDelegatorReward{
-		DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ValidatorAddress: valAddr,
+		DelegatorAddress: testDelegator1,
+		ValidatorAddress: testValAbc,
 	}
 	txBytes := marshalTx(t, cdc, msg)
 
@@ -151,7 +167,7 @@ func TestNewGaia_MsgWithdrawDelegatorReward_WithConstraint(t *testing.T) {
 				Constraint: &types.Constraint{
 					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
 					Value: &types.Constraint_FixedValue{
-						FixedValue: valAddr,
+						FixedValue: testValAbc,
 					},
 				},
 			},
@@ -169,8 +185,8 @@ func TestNewGaia_UnknownProtocol_Fails(t *testing.T) {
 	cdc := buildTestCodec()
 
 	msg := &banktypes.MsgSend{
-		FromAddress: "cosmos1fromxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		ToAddress:   "cosmos1toxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		FromAddress: testDelegator1,
+		ToAddress:   testDelegator2,
 		Amount:      cosmostypes.NewCoins(cosmostypes.NewCoin("uatom", math.NewInt(1))),
 	}
 	txBytes := marshalTx(t, cdc, msg)
@@ -182,4 +198,107 @@ func TestNewGaia_UnknownProtocol_Fails(t *testing.T) {
 
 	err := g.Evaluate(rule, txBytes)
 	assert.Error(t, err, "unknown protocol must still return an error")
+}
+
+// --- Negative tests (C3): verify that wrong-HRP addresses are REJECTED ---
+
+// TestNewGaia_RedelegateRejectsAccountHRPInSrcValidatorField proves that a
+// cosmos1... (account HRP) address in validator_src_address is rejected.
+// A rule constraining validator_src_address to cosmosvaloper1... would otherwise
+// silently accept a cosmos1... address — a fail-open bypass (codex C1).
+func TestNewGaia_RedelegateRejectsAccountHRPInSrcValidatorField(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testDelegator1,
+		ValidatorSrcAddress: testAccountAsValidator, // cosmos1... where cosmosvaloper1... required
+		ValidatorDstAddress: testValDst,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_redelegate.redelegate",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.Error(t, err, "account HRP in validator_src_address must be rejected")
+	assert.True(t, strings.Contains(err.Error(), "validator_src_address") || strings.Contains(err.Error(), "HRP"),
+		"error should mention the field or HRP mismatch, got: %s", err)
+}
+
+// TestNewGaia_RedelegateRejectsAccountHRPInDstValidatorField proves the same
+// for validator_dst_address.
+func TestNewGaia_RedelegateRejectsAccountHRPInDstValidatorField(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testDelegator1,
+		ValidatorSrcAddress: testValSrc,
+		ValidatorDstAddress: testAccountAsValidator, // cosmos1... where cosmosvaloper1... required
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_redelegate.redelegate",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.Error(t, err, "account HRP in validator_dst_address must be rejected")
+	assert.True(t, strings.Contains(err.Error(), "validator_dst_address") || strings.Contains(err.Error(), "HRP"),
+		"error should mention the field or HRP mismatch, got: %s", err)
+}
+
+// TestNewGaia_WithdrawRejectsAccountHRPInValidatorField proves that a cosmos1...
+// address in MsgWithdrawDelegatorReward.ValidatorAddress is rejected.
+func TestNewGaia_WithdrawRejectsAccountHRPInValidatorField(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &distributiontypes.MsgWithdrawDelegatorReward{
+		DelegatorAddress: testDelegator1,
+		ValidatorAddress: testAccountAsValidator, // cosmos1... where cosmosvaloper1... required
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_withdraw_rewards.withdraw_rewards",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.Error(t, err, "account HRP in validator_address must be rejected")
+	assert.True(t, strings.Contains(err.Error(), "validator_address") || strings.Contains(err.Error(), "HRP"),
+		"error should mention the field or HRP mismatch, got: %s", err)
+}
+
+// TestNewGaia_RedelegateRejectsValidatorHRPInDelegatorField is a symmetric
+// defensive test: a cosmosvaloper1... address in DelegatorAddress must also be
+// rejected. This closes the reverse confusion direction.
+func TestNewGaia_RedelegateRejectsValidatorHRPInDelegatorField(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testValidatorAsDelegator, // cosmosvaloper1... where cosmos1... required
+		ValidatorSrcAddress: testValSrc,
+		ValidatorDstAddress: testValDst,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_redelegate.redelegate",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.Error(t, err, "validator HRP in delegator_address must be rejected")
+	assert.True(t, strings.Contains(err.Error(), "delegator_address") || strings.Contains(err.Error(), "HRP"),
+		"error should mention the field or HRP mismatch, got: %s", err)
 }

--- a/engine/cosmos/gaia/gaia_test.go
+++ b/engine/cosmos/gaia/gaia_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +13,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -35,7 +35,7 @@ const (
 	// Wrong-HRP addresses used in negative tests.
 	// These are valid bech32 but carry the wrong prefix for the field they are
 	// placed in — proving that the extractor rejects them.
-	testAccountAsValidator  = "cosmos1gvll0hewp46cvm8wm6hqysyh2cve38j5k7npf7"   // "cosmos" HRP where "cosmosvaloper" is required
+	testAccountAsValidator   = "cosmos1gvll0hewp46cvm8wm6hqysyh2cve38j5k7npf7"        // "cosmos" HRP where "cosmosvaloper" is required
 	testValidatorAsDelegator = "cosmosvaloper1d8dg727hwgyqq6h34nwysvsm3fqkvcs3fvndue" // "cosmosvaloper" HRP where "cosmos" is required
 )
 
@@ -221,6 +221,15 @@ func TestNewGaia_RedelegateRejectsAccountHRPInSrcValidatorField(t *testing.T) {
 	rule := &types.Rule{
 		Resource: "cosmos.staking_redelegate.redelegate",
 		Effect:   types.Effect_EFFECT_ALLOW,
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "validator_src_address",
+				Constraint: &types.Constraint{
+					Type:  types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{FixedValue: testValSrc},
+				},
+			},
+		},
 	}
 
 	err := g.Evaluate(rule, txBytes)
@@ -246,6 +255,15 @@ func TestNewGaia_RedelegateRejectsAccountHRPInDstValidatorField(t *testing.T) {
 	rule := &types.Rule{
 		Resource: "cosmos.staking_redelegate.redelegate",
 		Effect:   types.Effect_EFFECT_ALLOW,
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "validator_dst_address",
+				Constraint: &types.Constraint{
+					Type:  types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{FixedValue: testValDst},
+				},
+			},
+		},
 	}
 
 	err := g.Evaluate(rule, txBytes)
@@ -269,6 +287,15 @@ func TestNewGaia_WithdrawRejectsAccountHRPInValidatorField(t *testing.T) {
 	rule := &types.Rule{
 		Resource: "cosmos.staking_withdraw_rewards.withdraw_rewards",
 		Effect:   types.Effect_EFFECT_ALLOW,
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "validator_address",
+				Constraint: &types.Constraint{
+					Type:  types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{FixedValue: testValAbc},
+				},
+			},
+		},
 	}
 
 	err := g.Evaluate(rule, txBytes)
@@ -295,6 +322,15 @@ func TestNewGaia_RedelegateRejectsValidatorHRPInDelegatorField(t *testing.T) {
 	rule := &types.Rule{
 		Resource: "cosmos.staking_redelegate.redelegate",
 		Effect:   types.Effect_EFFECT_ALLOW,
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "delegator_address",
+				Constraint: &types.Constraint{
+					Type:  types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{FixedValue: testDelegator1},
+				},
+			},
+		},
 	}
 
 	err := g.Evaluate(rule, txBytes)

--- a/engine/cosmos/gaia/gaia_test.go
+++ b/engine/cosmos/gaia/gaia_test.go
@@ -1,0 +1,185 @@
+package gaia_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vultisig/recipes/engine/cosmos/gaia"
+	"github.com/vultisig/recipes/types"
+)
+
+// buildTestCodec creates a codec that can pack Any messages for test tx construction.
+// We need our own codec here because gaia.Engine's codec is unexported.
+func buildTestCodec() codec.Codec {
+	ir := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(ir)
+	banktypes.RegisterInterfaces(ir)
+	stakingtypes.RegisterInterfaces(ir)
+	distributiontypes.RegisterInterfaces(ir)
+	return codec.NewProtoCodec(ir)
+}
+
+// marshalTx serialises a single-message tx to proto bytes.
+func marshalTx(t *testing.T, cdc codec.Codec, msg cosmostypes.Msg) []byte {
+	t.Helper()
+	any, err := codectypes.NewAnyWithValue(msg)
+	require.NoError(t, err)
+	tx := &sdktx.Tx{
+		Body:     &sdktx.TxBody{Messages: []*codectypes.Any{any}},
+		AuthInfo: &sdktx.AuthInfo{},
+	}
+	raw, err := cdc.Marshal(tx)
+	require.NoError(t, err)
+	return raw
+}
+
+// TestNewGaia_MsgBeginRedelegate_Dispatch verifies that gaia.NewGaia().Evaluate
+// does NOT return "unsupported TypeUrl" for MsgBeginRedelegate — the core of B1.
+func TestNewGaia_MsgBeginRedelegate_Dispatch(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ValidatorDstAddress: "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_redelegate.redelegate",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	// The dispatch gate must pass (no "unsupported TypeUrl" or "unsupported protocol").
+	// Parameter constraints are empty so validation stops at dispatch — that is enough
+	// to prove the wiring is correct.
+	require.NoError(t, err, "MsgBeginRedelegate must not hit unsupported TypeUrl in gaia.NewGaia()")
+}
+
+// TestNewGaia_MsgWithdrawDelegatorReward_Dispatch verifies the same for
+// MsgWithdrawDelegatorReward.
+func TestNewGaia_MsgWithdrawDelegatorReward_Dispatch(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &distributiontypes.MsgWithdrawDelegatorReward{
+		DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ValidatorAddress: "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_withdraw_rewards.withdraw_rewards",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.NoError(t, err, "MsgWithdrawDelegatorReward must not hit unsupported TypeUrl in gaia.NewGaia()")
+}
+
+// TestNewGaia_MsgBeginRedelegate_WithConstraint exercises the full dispatch path
+// including a parameter constraint on validator_dst_address, confirming that
+// NewGaia() routes redelegate params all the way through extractParameterValue.
+func TestNewGaia_MsgBeginRedelegate_WithConstraint(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	const dstValidator = "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ValidatorSrcAddress: "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ValidatorDstAddress: dstValidator,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(500_000)),
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_redelegate.redelegate",
+		Effect:   types.Effect_EFFECT_ALLOW,
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "validator_dst_address",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: dstValidator,
+					},
+				},
+			},
+		},
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.NoError(t, err, "constraint on validator_dst_address must pass through gaia.NewGaia()")
+}
+
+// TestNewGaia_MsgWithdrawDelegatorReward_WithConstraint exercises the full dispatch
+// path for withdraw_rewards with a validator_address constraint.
+func TestNewGaia_MsgWithdrawDelegatorReward_WithConstraint(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	const valAddr = "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+	msg := &distributiontypes.MsgWithdrawDelegatorReward{
+		DelegatorAddress: "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ValidatorAddress: valAddr,
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.staking_withdraw_rewards.withdraw_rewards",
+		Effect:   types.Effect_EFFECT_ALLOW,
+		ParameterConstraints: []*types.ParameterConstraint{
+			{
+				ParameterName: "validator_address",
+				Constraint: &types.Constraint{
+					Type: types.ConstraintType_CONSTRAINT_TYPE_FIXED,
+					Value: &types.Constraint_FixedValue{
+						FixedValue: valAddr,
+					},
+				},
+			},
+		},
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	require.NoError(t, err, "constraint on validator_address must pass through gaia.NewGaia()")
+}
+
+// TestNewGaia_UnknownProtocol_Fails confirms that an unknown protocol ID still
+// returns an error, so we haven't broken the gate by being too permissive.
+func TestNewGaia_UnknownProtocol_Fails(t *testing.T) {
+	g := gaia.NewGaia()
+	cdc := buildTestCodec()
+
+	msg := &banktypes.MsgSend{
+		FromAddress: "cosmos1fromxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		ToAddress:   "cosmos1toxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		Amount:      cosmostypes.NewCoins(cosmostypes.NewCoin("uatom", math.NewInt(1))),
+	}
+	txBytes := marshalTx(t, cdc, msg)
+
+	rule := &types.Rule{
+		Resource: "cosmos.unknown_protocol.transfer",
+		Effect:   types.Effect_EFFECT_ALLOW,
+	}
+
+	err := g.Evaluate(rule, txBytes)
+	assert.Error(t, err, "unknown protocol must still return an error")
+}

--- a/sdk/cosmos/sdk.go
+++ b/sdk/cosmos/sdk.go
@@ -18,6 +18,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/vultisig/mobile-tss-lib/tss"
 
 	chainCosmos "github.com/vultisig/recipes/chain/cosmos"
@@ -36,6 +38,8 @@ func NewSDK(rpcClient RPCClient) *SDK {
 	ir := codectypes.NewInterfaceRegistry()
 	cryptocodec.RegisterInterfaces(ir)
 	banktypes.RegisterInterfaces(ir)
+	stakingtypes.RegisterInterfaces(ir)
+	distributiontypes.RegisterInterfaces(ir)
 
 	return &SDK{
 		rpcClient: rpcClient,

--- a/sdk/cosmos/sdk.go
+++ b/sdk/cosmos/sdk.go
@@ -262,5 +262,3 @@ func (s *SDK) DeriveSigningHashes(txBytes []byte, opts sdk.DeriveOptions) ([]sdk
 		},
 	}, nil
 }
-
-


### PR DESCRIPTION
## Summary

Wire the two generic Cosmos SDK staking/distribution messages through the chain codec, the policy engine, and the signing SDK. Without these, even once mcp-ts registers the corresponding write tools (mcp-ts PR #72), the verifier would reject any `redelegate` or `withdraw_rewards` tx — a silent gate that turns _shipped_ into _shipped-but-bounced_.

These two msgs are generic Cosmos SDK and unlock the same code path for **Cosmos Hub, Osmosis, Kujira, Akash, Dydx, Noble** alongside **Terra (phoenix-1)** and **Terra Classic (columbus-5)**.

## Changes

- `chain/cosmos/types.go` — add `MessageTypeBeginRedelegate` + `MessageTypeWithdrawDelegatorReward` enum values and their canonical TypeUrl constants:
  - `/cosmos.staking.v1beta1.MsgBeginRedelegate`
  - `/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward`
- `chain/cosmos/chain.go` — register `stakingtypes` + `distributiontypes` interfaces on the chain codec so protobuf-Any unpack works.
- `engine/cosmos/cosmos.go` — add `unpackMsgBeginRedelegate` + `unpackMsgWithdrawDelegatorReward` helpers, dispatch them in `extractParameterValue`, and add per-message parameter extractors. The redelegate extractor enforces `amount > 0` and `src != dst` (both invariants the chain rejects, but worth failing fast on).
- `sdk/cosmos/sdk.go` — register staking + distribution interfaces in `NewSDK` so the signing/hashing path used by verifier's tx indexer can decode these msgs.

## Pattern fidelity

Mirrors the existing `MsgSend` / `MsgDeposit` scaffolding exactly:
- Same TypeUrl-constant + MessageType-enum pattern as `TypeUrlCosmosMsgSend`.
- Same unpack-helper signature as `unpackMsgSend` / `unpackMsgDeposit`.
- Same `extractParameterValue` switch dispatch pattern.
- No new public types; no new packages; no protobuf changes (cosmos-sdk types are upstream).

## Tests

- `chain/cosmos/types_test.go` (new):
  - `MessageType.String()` for the two new enum values
  - TypeUrl pinning (canonical Cosmos SDK strings)
  - Codec round-trip via `Any` pack/unpack on a real chain instance
- `engine/cosmos/cosmos_test.go` (new):
  - Unpack from a real `Any` exercises the registered interfaces
  - Per-parameter extraction (delegator, src/dst validator, amount, denom)
  - Negative paths: zero amount, negative amount, src == dst, unknown param, wrong message type passed to unpacker
  - End-to-end dispatch through `extractParameterValue` for both new msg types

## Paired PR

- vultisig/verifier#581 — bumps the recipes dependency and adds tx-indexer hash tests for the two new message types.

## Refs

- `vultisig-ops/.spikes/terra-readiness-checkpoint-2026-04-30.md` § B.5 — gap evidence
- `vultisig-ops/.spikes/terra-product-plan.md` — Phase 1.5 description

## Codex 5.4 dual-review summary

Run pre-promotion against both diffs (recipes#589 + verifier#581) simultaneously. One actionable finding, four affirmations:

1. ✅ **Type URLs correct** — `cosmos.staking.v1beta1.MsgBeginRedelegate` + `cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward` match cosmos-sdk v0.50.11 upstream verbatim.
2. ✅ **Bech32 prefix non-validation** is the right call for the generic engine — chain keepers do real address decode at execution time.
3. ✅ **Amount validation** (`IsNil + IsPositive`) covers structural cases. Deliberate looseness vs upstream's `IsValid()` + bond-denom check is acceptable for a policy-extractor layer.
4. ✅ **Cross-registering** generic cosmos staking/distribution types into THORChain/Maya SDK instances in `chains_list.go` is harmless — disjoint type URLs.
5. ⚠️ **Doc nit** — original test comment claimed test proves SDK interface registration was necessary, but `Sign()` only round-trips outer `tx.Tx` envelope. Comment fixed in commit 599351c8.

Subsequent `recipes#589` CR finding (withdraw addresses missing non-empty validation) addressed in commit 1d5f4ac with 3 regression sub-tests.

## receipts

```
ok  	github.com/vultisig/recipes/chain/cosmos	0.888s
ok  	github.com/vultisig/recipes/engine/cosmos	1.182s
ok  	github.com/vultisig/recipes/sdk/cosmos	2.693s
ok  	github.com/vultisig/recipes/sdk/cosmos/gaia	2.905s
ok  	github.com/vultisig/recipes/sdk/cosmos/maya	2.629s
ok  	github.com/vultisig/recipes/sdk/cosmos/thorchain	2.550s
ok  	github.com/vultisig/recipes/engine	1.776s
ok  	github.com/vultisig/recipes/engine/evm	1.852s
ok  	github.com/vultisig/recipes/engine/solana	1.686s
ok  	github.com/vultisig/recipes/engine/tron	2.042s
ok  	github.com/vultisig/recipes/engine/utxo/bitcoin	2.115s
ok  	github.com/vultisig/recipes/engine/utxo/bitcoincash	2.482s
ok  	github.com/vultisig/recipes/engine/utxo/dogecoin	2.597s
ok  	github.com/vultisig/recipes/engine/utxo/litecoin	2.176s
ok  	github.com/vultisig/recipes/engine/utxo/zcash	2.950s
ok  	github.com/vultisig/recipes/engine/xrpl	3.298s
ok  	github.com/vultisig/recipes/metarule	2.902s
ok  	github.com/vultisig/recipes/resolver	6.915s
[+ all sdk packages: bridge, btc, evm, evm/aavev3, solana, swap, tron, xrpl, zcash — full suite green]
```

Robot-generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Cosmos staking redelegation and delegator reward withdrawal operations, with protocol/operation registration and improved message decoding.
  * Protocols now expose redelegate and withdraw-rewards operations for GAIA.

* **Bug Fixes / Improvements**
  * Enhanced parameter extraction and stricter validation (delegator/validator address formats, HRP checks, nonzero positive amounts, distinct src/dst).

* **Tests**
  * Added unit and end-to-end tests covering unpacking, dispatch, extraction, validation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
