### PR TITLE
feat(swap): add AffiliateBps + AffiliateAddress to QuoteRequest

### DIFF
--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -117,6 +117,20 @@ type QuoteRequest struct {
 	Sender       string   // Sender address
 	ToleranceBps *int     // Optional THOR/Maya quote tolerance override in basis points (typically 0-10000, where 10000 = 100%)
 
+	// AffiliateBps is the optional affiliate fee in basis points (100 = 1%).
+	// nil means no affiliate fee. 0 means an explicit "no fee" signal (caller
+	// disabled it). >0 enables the upstream provider's affiliate hook with
+	// the provided bps. Per-provider param naming (affiliate_bps,
+	// referrer+fee, integrator+fee, platformFeeBps+feeAccount)
+	// is handled in the provider-specific quote builders.
+	AffiliateBps *int
+
+	// AffiliateAddress is the on-chain destination for affiliate fees. Empty
+	// means use the provider/chain default treasury (resolved per-chain in
+	// the affiliate chain maps). Non-empty overrides the default. For
+	// Solana, this should be a base58-encoded SPL token account.
+	AffiliateAddress string
+
 	// Preference specifies which providers to use and in what order.
 	// If nil, uses default provider order.
 	Preference *ProviderPreference


### PR DESCRIPTION
## what

Extends `QuoteRequest` in `sdk/swap/types.go` with two optional fields - `AffiliateBps *int` and `AffiliateAddress string` - that serve as the Wave 2 foundation for affiliate fee plumbing across THORChain, Maya, 1inch, LiFi, and Jupiter providers.

## why

Billing roadmap Wave 2 (context: vultisig/agent-backend#629, vultisig/agent-backend#598) needs per-provider affiliate hooks. Each provider uses different param names (`affiliate_bps`, `referrer`+`fee`, `integrator`+`fee`, `platformFeeBps`+`feeAccount`) but the caller interface is unified here. Wave 2 provider PRs (THORChain/Maya, 1inch/LiFi, Jupiter) consume these fields without needing a type change.

## how

```go
// AffiliateBps is the optional affiliate fee in basis points (100 = 1%).
// nil means no affiliate fee. 0 means an explicit "no fee" signal (caller
// disabled it). >0 enables the upstream provider's affiliate hook with
// the provided bps. Per-provider param naming (affiliate_bps,
// referrer+fee, integrator+fee, platformFeeBps+feeAccount)
// is handled in the provider-specific quote builders.
AffiliateBps *int

// AffiliateAddress is the on-chain destination for affiliate fees. Empty
// means use the provider/chain default treasury (resolved per-chain in
// the affiliate chain maps). Non-empty overrides the default. For
// Solana, this should be a base58-encoded SPL token account.
AffiliateAddress string
```

No callsite changes in this PR. Existing callers compile unchanged since both fields are zero-value safe (nil pointer + empty string = no fee emitted).

## risk

Low - additive optional fields, no existing callsite breakage. `go build ./sdk/...` and `go vet ./sdk/...` clean.

## receipts

```
$ go build ./sdk/...
(exit 0)

$ go vet ./sdk/...
(exit 0)
```

Note: `go build ./...` has a pre-existing linker error in `cmd/` (sonic/ast encoding issue, unrelated to this diff - confirmed on main before this branch).

## bead

Closes vultisig-ops bead W2-1 (vultisig-ops-3 in beads-local)

---

🤖 Agent-generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap quote requests now support optional affiliate fee configuration parameters. Developers can specify affiliate basis points to control fee behavior and optionally provide an on-chain address for fee distributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/recipes/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->