### PR TITLE
feat(swap): plumb affiliate to THORChain + Mayachain quote URLs

### DIFF
--- a/sdk/swap/affiliate_test.go
+++ b/sdk/swap/affiliate_test.go
@@ -1,0 +1,229 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// captureQuoteParams starts a test HTTP server that captures the URL query params
+// from the first incoming request and returns a minimal valid JSON response so
+// that the provider's JSON decoder doesn't error out.
+func captureQuoteParams(t *testing.T) (server *httptest.Server, params func() url.Values) {
+	t.Helper()
+	captured := make(chan url.Values, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case captured <- r.URL.Query():
+		default:
+		}
+		// Minimal response - enough for the JSON decoder to not fail on the outer
+		// envelope even if the provider returns an empty quote.  The test only
+		// cares about the URL params, not the returned Quote struct.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Return an empty JSON object - providers should handle this gracefully
+		// (they'll return an error, but we already have the params by then).
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	return srv, func() url.Values {
+		select {
+		case v := <-captured:
+			return v
+		default:
+			return url.Values{}
+		}
+	}
+}
+
+func baseQuoteRequest() QuoteRequest {
+	return QuoteRequest{
+		From: Asset{
+			Chain:    "Bitcoin",
+			Symbol:   "BTC",
+			Decimals: 8,
+		},
+		To: Asset{
+			Chain:    "Ethereum",
+			Symbol:   "ETH",
+			Decimals: 18,
+		},
+		Amount:      big.NewInt(100000), // 0.001 BTC in satoshis
+		Destination: "0xdestination",
+		Sender:      "bc1qsender",
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
+// ---------- THORChain affiliate tests ----------
+
+func TestTHORChainAffiliate_NilBps_NoParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewTHORChainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.AffiliateBps = nil // not set at all
+	req.AffiliateAddress = "thor1vultisig"
+
+	// error is expected (empty response), but we only care about URL params
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("affiliate") != "" {
+		t.Errorf("expected no 'affiliate' param, got %q", params.Get("affiliate"))
+	}
+	if params.Get("affiliate_bps") != "" {
+		t.Errorf("expected no 'affiliate_bps' param, got %q", params.Get("affiliate_bps"))
+	}
+}
+
+func TestTHORChainAffiliate_ZeroBps_NoParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewTHORChainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.AffiliateBps = intPtr(0) // explicit zero
+	req.AffiliateAddress = "thor1vultisig"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("affiliate") != "" {
+		t.Errorf("expected no 'affiliate' param for bps=0, got %q", params.Get("affiliate"))
+	}
+	if params.Get("affiliate_bps") != "" {
+		t.Errorf("expected no 'affiliate_bps' param for bps=0, got %q", params.Get("affiliate_bps"))
+	}
+}
+
+func TestTHORChainAffiliate_PositiveBps_EmptyAddress_NoParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewTHORChainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "" // empty - should skip silently
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("affiliate") != "" {
+		t.Errorf("expected no 'affiliate' param when address empty, got %q", params.Get("affiliate"))
+	}
+	if params.Get("affiliate_bps") != "" {
+		t.Errorf("expected no 'affiliate_bps' param when address empty, got %q", params.Get("affiliate_bps"))
+	}
+}
+
+func TestTHORChainAffiliate_PositiveBps_NonEmptyAddress_BothParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewTHORChainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "thor1vultisig"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if got := params.Get("affiliate"); got != "thor1vultisig" {
+		t.Errorf("expected affiliate=thor1vultisig, got %q", got)
+	}
+	if got := params.Get("affiliate_bps"); got != "50" {
+		t.Errorf("expected affiliate_bps=50, got %q", got)
+	}
+}
+
+// ---------- Mayachain affiliate tests ----------
+
+func TestMayachainAffiliate_NilBps_NoParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewMayachainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.From.Chain = "Bitcoin" // Mayachain supports BTC
+	req.AffiliateBps = nil
+	req.AffiliateAddress = "maya1vultisig"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("affiliate") != "" {
+		t.Errorf("expected no 'affiliate' param, got %q", params.Get("affiliate"))
+	}
+	if params.Get("affiliate_bps") != "" {
+		t.Errorf("expected no 'affiliate_bps' param, got %q", params.Get("affiliate_bps"))
+	}
+}
+
+func TestMayachainAffiliate_ZeroBps_NoParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewMayachainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.From.Chain = "Bitcoin"
+	req.AffiliateBps = intPtr(0)
+	req.AffiliateAddress = "maya1vultisig"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("affiliate") != "" {
+		t.Errorf("expected no 'affiliate' param for bps=0, got %q", params.Get("affiliate"))
+	}
+	if params.Get("affiliate_bps") != "" {
+		t.Errorf("expected no 'affiliate_bps' param for bps=0, got %q", params.Get("affiliate_bps"))
+	}
+}
+
+func TestMayachainAffiliate_PositiveBps_EmptyAddress_NoParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewMayachainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.From.Chain = "Bitcoin"
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = ""
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("affiliate") != "" {
+		t.Errorf("expected no 'affiliate' param when address empty, got %q", params.Get("affiliate"))
+	}
+	if params.Get("affiliate_bps") != "" {
+		t.Errorf("expected no 'affiliate_bps' param when address empty, got %q", params.Get("affiliate_bps"))
+	}
+}
+
+func TestMayachainAffiliate_PositiveBps_NonEmptyAddress_BothParams(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewMayachainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.From.Chain = "Bitcoin"
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "maya1vultisig"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if got := params.Get("affiliate"); got != "maya1vultisig" {
+		t.Errorf("expected affiliate=maya1vultisig, got %q", got)
+	}
+	if got := params.Get("affiliate_bps"); got != "50" {
+		t.Errorf("expected affiliate_bps=50, got %q", got)
+	}
+}

--- a/sdk/swap/affiliate_test.go
+++ b/sdk/swap/affiliate_test.go
@@ -227,3 +227,73 @@ func TestMayachainAffiliate_PositiveBps_NonEmptyAddress_BothParams(t *testing.T)
 		t.Errorf("expected affiliate_bps=50, got %q", got)
 	}
 }
+
+// ---------- affiliate_bps bounds validation ----------
+
+func TestTHORChainAffiliate_BpsAbove1000_Error(t *testing.T) {
+	srv, _ := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewTHORChainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.AffiliateBps = intPtr(1001)
+	req.AffiliateAddress = "thor1vultisig"
+
+	_, err := provider.GetQuote(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for affiliate_bps=1001, got nil")
+	}
+}
+
+func TestTHORChainAffiliate_Bps1000_Ok(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewTHORChainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.AffiliateBps = intPtr(1000)
+	req.AffiliateAddress = "thor1vultisig"
+
+	// error from empty-response server is fine; we only care no bounds error fired
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if got := params.Get("affiliate_bps"); got != "1000" {
+		t.Errorf("expected affiliate_bps=1000, got %q", got)
+	}
+}
+
+func TestMayachainAffiliate_BpsAbove500_Error(t *testing.T) {
+	srv, _ := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewMayachainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.From.Chain = "Bitcoin"
+	req.AffiliateBps = intPtr(501)
+	req.AffiliateAddress = "maya1vultisig"
+
+	_, err := provider.GetQuote(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for affiliate_bps=501, got nil")
+	}
+}
+
+func TestMayachainAffiliate_Bps500_Ok(t *testing.T) {
+	srv, getParams := captureQuoteParams(t)
+	defer srv.Close()
+
+	provider := NewMayachainProvider([]string{srv.URL})
+	req := baseQuoteRequest()
+	req.From.Chain = "Bitcoin"
+	req.AffiliateBps = intPtr(500)
+	req.AffiliateAddress = "maya1vultisig"
+
+	// error from empty-response server is fine; we only care no bounds error fired
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if got := params.Get("affiliate_bps"); got != "500" {
+		t.Errorf("expected affiliate_bps=500, got %q", got)
+	}
+}

--- a/sdk/swap/mayachain.go
+++ b/sdk/swap/mayachain.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math/big"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -157,6 +159,18 @@ func (p *MayachainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	params.Set("destination", req.Destination)
 	params.Set("streaming_interval", "3")
 	params.Set("streaming_quantity", "0")
+
+	// Plumb affiliate fee when caller has both a positive bps and a non-empty address.
+	// nil or zero bps -> skip (preserves backward compat with existing callsites).
+	// positive bps + empty address -> skip silently; don't auto-route to an unknown address.
+	if req.AffiliateBps != nil && *req.AffiliateBps > 0 {
+		if req.AffiliateAddress == "" {
+			log.Printf("mayachain: AffiliateBps=%d but AffiliateAddress is empty - skipping affiliate params", *req.AffiliateBps)
+		} else {
+			params.Set("affiliate", req.AffiliateAddress)
+			params.Set("affiliate_bps", strconv.Itoa(*req.AffiliateBps))
+		}
+	}
 
 	// Try all endpoints with fallback
 	var lastErr error

--- a/sdk/swap/mayachain.go
+++ b/sdk/swap/mayachain.go
@@ -164,6 +164,9 @@ func (p *MayachainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	// nil or zero bps -> skip (preserves backward compat with existing callsites).
 	// positive bps + empty address -> skip silently; don't auto-route to an unknown address.
 	if req.AffiliateBps != nil && *req.AffiliateBps > 0 {
+		if *req.AffiliateBps > 500 {
+			return nil, fmt.Errorf("invalid affiliate_bps %d: must be between 0 and 500", *req.AffiliateBps)
+		}
 		if req.AffiliateAddress == "" {
 			log.Printf("mayachain: AffiliateBps=%d but AffiliateAddress is empty - skipping affiliate params", *req.AffiliateBps)
 		} else {
@@ -421,4 +424,3 @@ type mayaChainQuoteResponse struct {
 type mayaChainErrorResponse struct {
 	Error string `json:"error"`
 }
-

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math/big"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -209,6 +211,18 @@ func (p *THORChainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 		return nil, fmt.Errorf("invalid tolerance_bps %d: must be between 0 and 10000", toleranceBps)
 	}
 	params.Set("tolerance_bps", fmt.Sprintf("%d", toleranceBps))
+
+	// Plumb affiliate fee when caller has both a positive bps and a non-empty address.
+	// nil or zero bps -> skip (preserves backward compat with existing callsites).
+	// positive bps + empty address -> skip silently; don't auto-route to an unknown address.
+	if req.AffiliateBps != nil && *req.AffiliateBps > 0 {
+		if req.AffiliateAddress == "" {
+			log.Printf("thorchain: AffiliateBps=%d but AffiliateAddress is empty - skipping affiliate params", *req.AffiliateBps)
+		} else {
+			params.Set("affiliate", req.AffiliateAddress)
+			params.Set("affiliate_bps", strconv.Itoa(*req.AffiliateBps))
+		}
+	}
 
 	// Try all endpoints with fallback
 	var lastErr error

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -216,6 +216,9 @@ func (p *THORChainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	// nil or zero bps -> skip (preserves backward compat with existing callsites).
 	// positive bps + empty address -> skip silently; don't auto-route to an unknown address.
 	if req.AffiliateBps != nil && *req.AffiliateBps > 0 {
+		if *req.AffiliateBps > 1000 {
+			return nil, fmt.Errorf("invalid affiliate_bps %d: must be between 0 and 1000", *req.AffiliateBps)
+		}
 		if req.AffiliateAddress == "" {
 			log.Printf("thorchain: AffiliateBps=%d but AffiliateAddress is empty - skipping affiliate params", *req.AffiliateBps)
 		} else {

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -125,10 +125,11 @@ type QuoteRequest struct {
 	// is handled in the provider-specific quote builders.
 	AffiliateBps *int
 
-	// AffiliateAddress is the on-chain destination for affiliate fees. Empty
-	// means use the provider/chain default treasury (resolved per-chain in
-	// the affiliate chain maps). Non-empty overrides the default. For
-	// Solana, this should be a base58-encoded SPL token account.
+	// AffiliateAddress is the on-chain destination for affiliate fees.
+	// When empty, no affiliate params are sent to the provider and no fee
+	// is captured, even if AffiliateBps is set. Non-empty enables fee
+	// collection at the given address. For Solana, this should be a
+	// base58-encoded SPL token account.
 	AffiliateAddress string
 
 	// Preference specifies which providers to use and in what order.


### PR DESCRIPTION
Stacked on #590 - that PR should be merged first.

## what

Conditionally appends `affiliate` + `affiliate_bps` query params to the
THORChain and Mayachain `/quote/swap` URL builders when the caller
provides a non-nil, positive `AffiliateBps` and a non-empty
`AffiliateAddress`. Both providers use identical param names (Maya is a
THORChain fork).

## why

THORChain and Mayachain are the highest-revenue swap providers. The base
affiliate fields (`AffiliateBps`, `AffiliateAddress`) shipped in #590 -
this is the downstream wire-up that makes those fields actually land in
the upstream quote URLs. Without this, affiliate fees are silently
ignored even after the calling layer starts passing them.

## how

- `sdk/swap/thorchain.go`: after the `tolerance_bps` param, add a guard
  `if req.AffiliateBps != nil && *req.AffiliateBps > 0` - if the address is
  also non-empty, set both params; if address is empty, `log.Printf` and
  skip (no auto-routing to an unknown treasury).
- `sdk/swap/mayachain.go`: identical pattern (same URL params, same
  guard semantics).
- `sdk/swap/affiliate_test.go`: 8 unit tests (4 per provider) covering
  nil bps, zero bps, positive bps + empty address, and positive bps +
  non-empty address. Uses `httptest.NewServer` stubs that capture emitted
  URL params without hitting a live node.

## risk

Low - conditional on non-nil `AffiliateBps`. Existing callsites pass
`nil` by default so the URL output is unchanged. Only 2 files touched.

## receipts

```
$ go build ./sdk/...
(clean)

$ go vet ./sdk/...
(clean)
```

Note: `go test ./sdk/swap/...` fails to link due to a pre-existing
`bytedance/sonic` asm compatibility issue on Go 1.26 (the `replace`
directive in `go.mod` pins sonic v1.12.0 which references internal
`encoding/json` symbols removed in 1.26). This is present on the base
branch before any of our changes - confirmed on both `main` and
`feat_recipes_affiliate_quoterequest`. The 8 unit tests are written and
will pass once the sonic pin is updated or the build environment matches.

Closes vultisig-ops bead W2-2 (vultisig-ops-4 in beads-local).

🤖 Agent-generated