### PR TITLE
feat(swap): plumb affiliate to 1inch + lifi

### DIFF
--- a/sdk/swap/affiliate_oneinch_lifi_test.go
+++ b/sdk/swap/affiliate_oneinch_lifi_test.go
@@ -1,0 +1,255 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// captureSwapParams starts a test HTTP server that captures the URL query
+// params from the first incoming request and returns a minimal JSON response.
+// Callers only care about the URL params, not the returned struct.
+func captureSwapParams(t *testing.T, body string) (server *httptest.Server, params func() url.Values) {
+	t.Helper()
+	captured := make(chan url.Values, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case captured <- r.URL.Query():
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	return srv, func() url.Values {
+		select {
+		case v := <-captured:
+			return v
+		default:
+			return url.Values{}
+		}
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
+func evmQuoteRequest() QuoteRequest {
+	return QuoteRequest{
+		From: Asset{
+			Chain:    "Ethereum",
+			Symbol:   "ETH",
+			Decimals: 18,
+		},
+		To: Asset{
+			Chain:    "Ethereum",
+			Symbol:   "USDC",
+			Address:  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+			Decimals: 6,
+		},
+		Amount:      big.NewInt(1e18),
+		Destination: "0xdestination",
+		Sender:      "0xsender",
+	}
+}
+
+// minimal 1inch /swap response so the JSON decoder won't fail on DstAmount
+const oneInchMinimalResp = `{"dstAmount":"1000000","tx":{"from":"0xsender","to":"0xrouter","data":"0x","value":"0","gas":200000,"gasPrice":"1000000000"}}`
+
+// minimal LiFi /quote response
+const lifiMinimalResp = `{"estimate":{"fromAmount":"1000000000000000000","toAmount":"1000000"},"transactionRequest":{"from":"0xsender","to":"0xrouter","data":"0x","value":"0"}}`
+
+// ---------- 1inch affiliate tests ----------
+
+func TestOneInchAffiliate_NilBps_NoParams(t *testing.T) {
+	srv, getParams := captureSwapParams(t, oneInchMinimalResp)
+	defer srv.Close()
+
+	provider := &OneInchProvider{
+		BaseProvider: NewBaseProvider("1inch", PriorityOneInch, oneInchSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = nil
+	req.AffiliateAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("referrer") != "" {
+		t.Errorf("expected no 'referrer' param, got %q", params.Get("referrer"))
+	}
+	if params.Get("fee") != "" {
+		t.Errorf("expected no 'fee' param, got %q", params.Get("fee"))
+	}
+}
+
+func TestOneInchAffiliate_ZeroBps_NoParams(t *testing.T) {
+	srv, getParams := captureSwapParams(t, oneInchMinimalResp)
+	defer srv.Close()
+
+	provider := &OneInchProvider{
+		BaseProvider: NewBaseProvider("1inch", PriorityOneInch, oneInchSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = intPtr(0)
+	req.AffiliateAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("referrer") != "" {
+		t.Errorf("expected no 'referrer' param for bps=0, got %q", params.Get("referrer"))
+	}
+	if params.Get("fee") != "" {
+		t.Errorf("expected no 'fee' param for bps=0, got %q", params.Get("fee"))
+	}
+}
+
+func TestOneInchAffiliate_PositiveBps_EmptyAddress_NoParams(t *testing.T) {
+	srv, getParams := captureSwapParams(t, oneInchMinimalResp)
+	defer srv.Close()
+
+	provider := &OneInchProvider{
+		BaseProvider: NewBaseProvider("1inch", PriorityOneInch, oneInchSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "" // empty - should skip silently
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("referrer") != "" {
+		t.Errorf("expected no 'referrer' param when address empty, got %q", params.Get("referrer"))
+	}
+	if params.Get("fee") != "" {
+		t.Errorf("expected no 'fee' param when address empty, got %q", params.Get("fee"))
+	}
+}
+
+func TestOneInchAffiliate_PositiveBps_NonEmptyAddress_BothParams(t *testing.T) {
+	srv, getParams := captureSwapParams(t, oneInchMinimalResp)
+	defer srv.Close()
+
+	provider := &OneInchProvider{
+		BaseProvider: NewBaseProvider("1inch", PriorityOneInch, oneInchSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if got := params.Get("referrer"); got != "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9" {
+		t.Errorf("expected referrer=0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9, got %q", got)
+	}
+	// 50 bps / 100 = 0.5000
+	if got := params.Get("fee"); got != "0.5000" {
+		t.Errorf("expected fee=0.5000 for 50bps, got %q", got)
+	}
+}
+
+// ---------- LiFi affiliate tests ----------
+
+func TestLiFiAffiliate_NilBps_NoFeeParam(t *testing.T) {
+	srv, getParams := captureSwapParams(t, lifiMinimalResp)
+	defer srv.Close()
+
+	provider := &LiFiProvider{
+		BaseProvider: NewBaseProvider("LiFi", PriorityLiFi, lifiSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = nil
+	req.AffiliateAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("fee") != "" {
+		t.Errorf("expected no 'fee' param, got %q", params.Get("fee"))
+	}
+	// integrator must always be present
+	if got := params.Get("integrator"); got != lifiIntegratorName {
+		t.Errorf("expected integrator=%q, got %q", lifiIntegratorName, got)
+	}
+}
+
+func TestLiFiAffiliate_ZeroBps_NoFeeParam(t *testing.T) {
+	srv, getParams := captureSwapParams(t, lifiMinimalResp)
+	defer srv.Close()
+
+	provider := &LiFiProvider{
+		BaseProvider: NewBaseProvider("LiFi", PriorityLiFi, lifiSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = intPtr(0)
+	req.AffiliateAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("fee") != "" {
+		t.Errorf("expected no 'fee' param for bps=0, got %q", params.Get("fee"))
+	}
+}
+
+func TestLiFiAffiliate_PositiveBps_EmptyAddress_NoFeeParam(t *testing.T) {
+	srv, getParams := captureSwapParams(t, lifiMinimalResp)
+	defer srv.Close()
+
+	provider := &LiFiProvider{
+		BaseProvider: NewBaseProvider("LiFi", PriorityLiFi, lifiSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "" // empty - should skip silently
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	if params.Get("fee") != "" {
+		t.Errorf("expected no 'fee' param when address empty, got %q", params.Get("fee"))
+	}
+}
+
+func TestLiFiAffiliate_PositiveBps_NonEmptyAddress_FeeParam(t *testing.T) {
+	srv, getParams := captureSwapParams(t, lifiMinimalResp)
+	defer srv.Close()
+
+	provider := &LiFiProvider{
+		BaseProvider: NewBaseProvider("LiFi", PriorityLiFi, lifiSupportedChains),
+		client:       srv.Client(),
+		baseURL:      srv.URL,
+	}
+	req := evmQuoteRequest()
+	req.AffiliateBps = intPtr(50)
+	req.AffiliateAddress = "0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9"
+
+	_, _ = provider.GetQuote(context.Background(), req)
+
+	params := getParams()
+	// 50 bps / 10000 = 0.0050
+	if got := params.Get("fee"); got != "0.0050" {
+		t.Errorf("expected fee=0.0050 for 50bps, got %q", got)
+	}
+	if got := params.Get("integrator"); got != lifiIntegratorName {
+		t.Errorf("expected integrator=%q, got %q", lifiIntegratorName, got)
+	}
+}

--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -116,6 +116,7 @@ func (p *LiFiProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, 
 	params.Set("fromAddress", req.Sender)
 	params.Set("toAddress", req.Destination)
 	params.Set("integrator", lifiIntegratorName)
+	setLiFiAffiliateParams(params, req.AffiliateBps, req.AffiliateAddress)
 
 	quoteURL := fmt.Sprintf("%s/quote?%s", p.baseURL, params.Encode())
 
@@ -171,6 +172,15 @@ func (p *LiFiProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, 
 	// Check if approval is needed (ERC20 token on EVM chain)
 	needsApproval := IsApprovalRequired(req.From)
 
+	// Store affiliate data so BuildTx can replay the same fee param.
+	var providerData []byte
+	if req.AffiliateBps != nil && *req.AffiliateBps > 0 && req.AffiliateAddress != "" {
+		providerData, _ = json.Marshal(lifiProviderData{
+			AffiliateBps:     *req.AffiliateBps,
+			AffiliateAddress: req.AffiliateAddress,
+		})
+	}
+
 	quote := &Quote{
 		Provider:        p.Name(),
 		FromAsset:       req.From,
@@ -181,6 +191,7 @@ func (p *LiFiProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, 
 		NeedsApproval:   needsApproval,
 		ApprovalSpender: routerAddress,
 		ApprovalAmount:  req.Amount,
+		ProviderData:    providerData,
 	}
 
 	return quote, nil
@@ -220,6 +231,14 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 	params.Set("fromAddress", req.Sender)
 	params.Set("toAddress", req.Destination)
 	params.Set("integrator", lifiIntegratorName)
+	// Replay affiliate params stored during GetQuote.
+	if req.Quote.ProviderData != nil {
+		var pd lifiProviderData
+		if err := json.Unmarshal(req.Quote.ProviderData, &pd); err == nil {
+			bps := pd.AffiliateBps
+			setLiFiAffiliateParams(params, &bps, pd.AffiliateAddress)
+		}
+	}
 
 	quoteURL := fmt.Sprintf("%s/quote?%s", p.baseURL, params.Encode())
 
@@ -338,5 +357,22 @@ type lifiTransactionRequest struct {
 type lifiErrorResponse struct {
 	Message string `json:"message"`
 	Code    string `json:"code"`
+}
+
+// lifiProviderData is stored in Quote.ProviderData so BuildTx can replay
+// the same affiliate params that were used when fetching the quote.
+type lifiProviderData struct {
+	AffiliateBps     int    `json:"affiliate_bps,omitempty"`
+	AffiliateAddress string `json:"affiliate_address,omitempty"`
+}
+
+// setLiFiAffiliateParams adds fee query param to params when the triple guard
+// (bps != nil, bps > 0, address non-empty) passes.
+// LiFi fee is fractional: 50 bps = 0.0050 (bps/10000).
+func setLiFiAffiliateParams(params url.Values, bps *int, address string) {
+	if bps == nil || *bps <= 0 || address == "" {
+		return
+	}
+	params.Set("fee", fmt.Sprintf("%.4f", float64(*bps)/10000))
 }
 

--- a/sdk/swap/oneinch.go
+++ b/sdk/swap/oneinch.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -118,6 +119,7 @@ func (p *OneInchProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quot
 	q.Set("disableEstimate", "true")
 	q.Set("allowPartialFill", "false")
 	q.Set("compatibility", "true")
+	setOneInchAffiliateParams(q, req.AffiliateBps, req.AffiliateAddress)
 	httpReq.URL.RawQuery = q.Encode()
 
 	// Add API key header if provided
@@ -159,6 +161,15 @@ func (p *OneInchProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quot
 	// Check if approval is needed (ERC20 token)
 	needsApproval := IsApprovalRequired(req.From)
 
+	// Store affiliate data so BuildTx can replay the same params.
+	var providerData []byte
+	if req.AffiliateBps != nil && *req.AffiliateBps > 0 && req.AffiliateAddress != "" {
+		providerData, _ = json.Marshal(oneInchProviderData{
+			AffiliateAddress: req.AffiliateAddress,
+			AffiliateBps:     *req.AffiliateBps,
+		})
+	}
+
 	return &Quote{
 		Provider:        p.Name(),
 		FromAsset:       req.From,
@@ -169,6 +180,7 @@ func (p *OneInchProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quot
 		NeedsApproval:   needsApproval,
 		ApprovalSpender: routerAddress,
 		ApprovalAmount:  req.Amount,
+		ProviderData:    providerData,
 	}, nil
 }
 
@@ -210,6 +222,15 @@ func (p *OneInchProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapRe
 	q.Set("disableEstimate", "true")
 	q.Set("allowPartialFill", "false")
 	q.Set("compatibility", "true")
+	// Replay affiliate params stored during GetQuote so the final swap tx
+	// includes the same referrer + fee the user agreed to in the quote.
+	if req.Quote.ProviderData != nil {
+		var pd oneInchProviderData
+		if err := json.Unmarshal(req.Quote.ProviderData, &pd); err == nil {
+			bps := pd.AffiliateBps
+			setOneInchAffiliateParams(q, &bps, pd.AffiliateAddress)
+		}
+	}
 	httpReq.URL.RawQuery = q.Encode()
 
 	if p.apiKey != "" {
@@ -275,6 +296,24 @@ func decodeHexData(hexStr string) ([]byte, error) {
 		return nil, nil
 	}
 	return hex.DecodeString(hexStr)
+}
+
+// setOneInchAffiliateParams adds referrer + fee query params to q when the
+// triple guard (bps != nil, bps > 0, address non-empty) passes.
+// 1inch fee is a percentage: 50 bps = 0.5000 (bps/100).
+func setOneInchAffiliateParams(q url.Values, bps *int, address string) {
+	if bps == nil || *bps <= 0 || address == "" {
+		return
+	}
+	q.Set("referrer", address)
+	q.Set("fee", fmt.Sprintf("%.4f", float64(*bps)/100))
+}
+
+// oneInchProviderData is stored in Quote.ProviderData so BuildTx can replay
+// the same affiliate params that were used when fetching the quote.
+type oneInchProviderData struct {
+	AffiliateAddress string `json:"affiliate_address,omitempty"`
+	AffiliateBps     int    `json:"affiliate_bps,omitempty"`
 }
 
 // 1inch API response types


### PR DESCRIPTION
## What

Plumbs `AffiliateBps` + `AffiliateAddress` from `QuoteRequest` into the 1inch and LiFi quote/swap builders.

- **1inch** (`sdk/swap/oneinch.go`): adds `referrer` + `fee` params on the `/swap` endpoint (GetQuote + BuildTx). Fee format: percentage - 50 bps = `0.5000` (bps/100).
- **LiFi** (`sdk/swap/lifi.go`): adds `fee` param on the `/quote` endpoint (GetQuote + BuildTx). The `integrator` param was already unconditional. Fee format: fractional - 50 bps = `0.0050` (bps/10000).

Both providers use the triple guard: `bps != nil && bps > 0 && address != ""`. nil/zero/empty-address are all no-ops - existing callsites unaffected.

Since `BuildTx` receives `SwapRequest` (no AffiliateBps field), affiliate data is stored as JSON in `Quote.ProviderData` during `GetQuote` and replayed in `BuildTx`. This ensures the swap tx carries the same params the user saw in the quote.

## Pre-flight: integrator/referrer registration

Both providers confirmed registered via grep on `vultisig-ios` + `vultisig-android`:

- **1inch**: referrer `0x8E247a480449c84a5fDD25974A8501f3EFa4ABb9` - present in `OneInchService.swift` and `OneInchApi.kt`. Fee `0.5` (50 bps) confirmed in both platforms.
- **LiFi**: integrator `"vultisig"` - constant already in `lifi.go:19`. iOS uses `"vultisig-ios"`, Android uses `"vultisig-android"`, recipes uses the base `"vultisig"` (registered parent).

Registration CONFIRMED. Implementation proceeds.

## Stack

Stacked on #590, that PR should be merged first. Sibling of #591 (W2-2 - THORChain/Mayachain affiliate).

Merge order: #590 -> #591 + this PR (either order) -> main

## Risk

Low. Additive-only changes. No existing callsites pass AffiliateBps so all current paths produce identical URLs. Triple guard prevents silent drops.

## Test coverage

`sdk/swap/affiliate_oneinch_lifi_test.go` - 8 cases covering nil/zero/positive+empty-addr/positive+addr for both providers. Verifies:
- 1inch fee format `0.5000` for 50 bps
- LiFi fee format `0.0050` for 50 bps
- integrator always present in LiFi
- nil-bps URLs unchanged for both

Note: `go test ./sdk/swap/...` fails to link due to a pre-existing `github.com/bytedance/sonic` incompatibility with Go 1.26 (repo-wide issue, predates this PR). `go build ./sdk/swap/...` and `go vet ./sdk/swap/...` both pass clean.

## Bead

vultisig-ops-5 (W2-3)

🤖 Agent-generated