### PR TITLE
fix(swap): forward tolerance_bps on mayachain quotes (zero-slippage fund-loss)

### DIFF
--- a/sdk/swap/mayachain.go
+++ b/sdk/swap/mayachain.go
@@ -188,6 +188,21 @@ func (p *MayachainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	params.Set("destination", req.Destination)
 	params.Set("streaming_interval", "3")
 	params.Set("streaming_quantity", "0")
+	// FUND-SAFETY: forward the slippage tolerance into the Mayanode quote so the
+	// returned memo carries a LIM (minimum-output) field. Without this, Mayanode
+	// builds a market-order memo ("=:c:maya1...", no limit) and the swap executes
+	// with ZERO slippage protection — full MEV/sandwich exposure on the entire
+	// amount — regardless of the caller's requested tolerance. Mirrors
+	// THORChainProvider.GetQuote exactly (same 2500bps default + 0-10000 bound);
+	// the omission here was a straight parity gap, not a design choice.
+	toleranceBps := 2500
+	if req.ToleranceBps != nil {
+		toleranceBps = *req.ToleranceBps
+	}
+	if toleranceBps < 0 || toleranceBps > 10000 {
+		return nil, fmt.Errorf("invalid tolerance_bps %d: must be between 0 and 10000", toleranceBps)
+	}
+	params.Set("tolerance_bps", fmt.Sprintf("%d", toleranceBps))
 
 	// Try all endpoints with fallback
 	var lastErr error

--- a/sdk/swap/mayachain_tolerance_test.go
+++ b/sdk/swap/mayachain_tolerance_test.go
@@ -1,0 +1,63 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// FUND-SAFETY regression: MayachainProvider.GetQuote must forward tolerance_bps
+// into the Mayanode /quote/swap request so the returned memo carries a LIM
+// (minimum-output) field. A missing tolerance_bps yields a market-order memo
+// ("=:c:maya1...", no limit) that executes with ZERO slippage protection —
+// full MEV/sandwich exposure on the whole amount — regardless of the caller's
+// requested tolerance. This mirrors THORChainProvider.GetQuote, which was
+// already forwarding it.
+func TestMayachainGetQuoteForwardsToleranceBps(t *testing.T) {
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		// We only assert on the OUTGOING query; the request is captured before
+		// this returns, so a stub error response is enough (no need to build a
+		// full valid quote body).
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"stub"}`))
+	}))
+	defer srv.Close()
+
+	p := NewMayachainProvider([]string{srv.URL})
+	base := QuoteRequest{
+		From:        Asset{Chain: "Bitcoin", Symbol: "BTC", Decimals: 8},
+		To:          Asset{Chain: "MayaChain", Symbol: "CACAO", Decimals: 10},
+		Amount:      big.NewInt(100_000_000),
+		Destination: "maya1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4n8gyj",
+	}
+
+	t.Run("explicit tolerance is forwarded", func(t *testing.T) {
+		captured = nil
+		tol := 150
+		req := base
+		req.ToleranceBps = &tol
+		_, _ = p.GetQuote(context.Background(), req)
+		if captured == nil {
+			t.Fatal("request never reached the server (GetQuote errored before fetchQuote)")
+		}
+		if got := captured.Get("tolerance_bps"); got != "150" {
+			t.Errorf("tolerance_bps = %q, want 150", got)
+		}
+	})
+
+	t.Run("omitted tolerance defaults to 2500 (parity with THORChain)", func(t *testing.T) {
+		captured = nil
+		_, _ = p.GetQuote(context.Background(), base)
+		if captured == nil {
+			t.Fatal("request never reached the server")
+		}
+		if got := captured.Get("tolerance_bps"); got != "2500" {
+			t.Errorf("default tolerance_bps = %q, want 2500", got)
+		}
+	})
+}


### PR DESCRIPTION
## what — MayaChain swaps ship with zero slippage protection (MEV / fund-loss)

`MayachainProvider.GetQuote` (`sdk/swap/mayachain.go`) builds the Mayanode `/quote/swap` request from `from_asset`, `to_asset`, `amount`, `destination`, `streaming_interval`, `streaming_quantity` — but **never sets `tolerance_bps`**, unlike its sibling `THORChainProvider.GetQuote` (same file) which does.

An omitted `tolerance_bps` makes Mayanode return a **market-order memo** (`=:c:maya1...`, no `LIM` field), so the swap executes with **zero slippage protection** — full MEV/sandwich exposure on the entire amount — **regardless** of the `slippage_tolerance_percent` the caller threaded down into `QuoteRequest.ToleranceBps`. The value is correctly plumbed by the consumers (the Go MCP's `build_swap_tx`/`execute_swap`, agent-backend-ts) and silently dropped only inside this provider.

## live verification (production Mayanode)

```
# no tolerance_bps → market order, no limit
GET /mayachain/quote/swap?from_asset=BTC.BTC&to_asset=MAYA.CACAO&amount=100000000&destination=maya1qqq…
  → "memo": "=:c:maya1qqq…"                              # NO limit

# with tolerance_bps → LIM present, and the API enforces it
GET …&tolerance_bps=9000  → "memo": "=:c:maya1qqq…:559503548616120"
GET …&tolerance_bps=100   → {"error":"… emit asset … less than price limit …"}
```

## how

Mirror `THORChainProvider.GetQuote` exactly — same `2500` bps default, same `0-10000` bound, same `params.Set("tolerance_bps", …)`. This is a straight parity fix; `mayachain.go` otherwise mirrors `thorchain.go` function-for-function. Added `mayachain_tolerance_test.go` (httptest captures the outgoing query) asserting `tolerance_bps` is forwarded (explicit value + the `2500` default when omitted).

## risk

Low, strictly corrective — the only prior behavior was "no slippage floor." Isolated to the MayaChain provider.

## note

The separate question of whether the shared `2500` bps (25%) default is itself too loose vs. 1inch/Jupiter's 1% (it applies to **both** THORChain and MayaChain today) is a broader design decision, not addressed here — this PR just brings Maya to parity so a floor exists at all.

## receipts

Live-verified against the production Mayanode API (curls above). Regression test passes under the go.mod toolchain (`GOTOOLCHAIN=go1.24.2 go test ./sdk/swap/ -run TestMayachainGetQuoteForwardsToleranceBps` — the package's test binary doesn't link on Go ≥1.24 due to a pinned `bytedance/sonic`/`go:linkname` incompatibility, unrelated to this change; `go build ./sdk/swap/` + `go vet` are clean on the default toolchain). Found by a fund-safety audit of the Go MCP swap builders that consume this provider.
