### PR TITLE
fix(swap): report relay's real minimumamount as minimumoutput (false zero-slippage signal)

### DIFF
--- a/sdk/swap/relay.go
+++ b/sdk/swap/relay.go
@@ -143,6 +143,20 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		return nil, fmt.Errorf("relay: invalid output amount %q", quoteResp.Details.CurrencyOut.Amount)
 	}
 
+	// FUND-SAFETY: Relay quotes carry a real minimum-output floor
+	// (currencyOut.minimumAmount). Despite the "solver-based" framing, live
+	// quotes return isFixedRate:false with a genuine gap (~1% observed
+	// ETH->USDC) between amount and minimumAmount, so reporting expectedOutput
+	// as MinimumOutput hands every caller a FALSE zero-slippage signal. Use the
+	// API's actual minimumAmount; fall back to expectedOutput only if the field
+	// is absent/unparseable.
+	minimumOutput := expectedOutput
+	if raw := quoteResp.Details.CurrencyOut.MinimumAmount; raw != "" {
+		if m, ok := new(big.Int).SetString(raw, 10); ok {
+			minimumOutput = m
+		}
+	}
+
 	// Separate approval and swap transaction steps.
 	var approvalStep *relayStepData
 	var txStep *relayStepData
@@ -183,7 +197,7 @@ func (p *RelayProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote,
 		ToAsset:         req.To,
 		FromAmount:      req.Amount,
 		ExpectedOutput:  expectedOutput,
-		MinimumOutput:   expectedOutput, // Relay is solver-based: no AMM slippage
+		MinimumOutput:   minimumOutput, // real floor from currencyOut.minimumAmount (Relay is NOT zero-slippage)
 		Router:          router,
 		NeedsApproval:   needsApproval,
 		ApprovalSpender: approvalSpender,
@@ -501,6 +515,7 @@ type relayDetails struct {
 
 type relayCurrencyOut struct {
 	Amount          string            `json:"amount"`
+	MinimumAmount   string            `json:"minimumAmount"`
 	AmountFormatted string            `json:"amountFormatted"`
 	Currency        relayCurrencyMeta `json:"currency"`
 }

--- a/sdk/swap/relay_minimum_output_test.go
+++ b/sdk/swap/relay_minimum_output_test.go
@@ -1,0 +1,62 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// FUND-SAFETY regression: RelayProvider.GetQuote must report the API's real
+// currencyOut.minimumAmount as Quote.MinimumOutput, not copy expectedOutput.
+// Relay quotes are NOT zero-slippage (live: isFixedRate:false, ~1% gap between
+// amount and minimumAmount), so copying expectedOutput hands callers a false
+// zero-slippage floor.
+func TestRelayGetQuoteUsesMinimumAmount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Minimal quote: distinct amount vs minimumAmount, no steps.
+		_, _ = w.Write([]byte(`{"steps":[],"details":{"currencyOut":{"amount":"1000000","minimumAmount":"990000","currency":{"symbol":"USDC"}}}}`))
+	}))
+	defer srv.Close()
+
+	p := NewRelayProvider(nil)
+	p.baseURL = srv.URL
+
+	q, err := p.GetQuote(context.Background(), QuoteRequest{
+		From:        Asset{Chain: "Ethereum", Symbol: "ETH", Decimals: 18},
+		To:          Asset{Chain: "Ethereum", Symbol: "USDC", Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Decimals: 6},
+		Amount:      big.NewInt(1_000_000_000_000_000_000),
+		Destination: "0x1234567890123456789012345678901234567890",
+		Sender:      "0x1234567890123456789012345678901234567890",
+	})
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if q.ExpectedOutput.String() != "1000000" {
+		t.Errorf("ExpectedOutput = %s, want 1000000", q.ExpectedOutput)
+	}
+	if q.MinimumOutput.String() != "990000" {
+		t.Errorf("MinimumOutput = %s, want 990000 (currencyOut.minimumAmount, NOT expectedOutput)", q.MinimumOutput)
+	}
+
+	// When the API omits minimumAmount, fall back to expectedOutput (no crash).
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"steps":[],"details":{"currencyOut":{"amount":"1000000","currency":{"symbol":"USDC"}}}}`))
+	}))
+	defer srv2.Close()
+	p.baseURL = srv2.URL
+	q2, err := p.GetQuote(context.Background(), QuoteRequest{
+		From:        Asset{Chain: "Ethereum", Symbol: "ETH", Decimals: 18},
+		To:          Asset{Chain: "Ethereum", Symbol: "USDC", Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Decimals: 6},
+		Amount:      big.NewInt(1_000_000_000_000_000_000),
+		Destination: "0x1234567890123456789012345678901234567890",
+		Sender:      "0x1234567890123456789012345678901234567890",
+	})
+	if err != nil {
+		t.Fatalf("GetQuote (no minimumAmount): %v", err)
+	}
+	if q2.MinimumOutput.String() != "1000000" {
+		t.Errorf("fallback MinimumOutput = %s, want 1000000 (expectedOutput)", q2.MinimumOutput)
+	}
+}


### PR DESCRIPTION
## what — Relay reports a false zero-slippage floor

`RelayProvider.GetQuote` (`sdk/swap/relay.go`) set:

```go
MinimumOutput: expectedOutput, // Relay is solver-based: no AMM slippage
```

That comment is **false**. A live `POST api.relay.link/quote` for ETH->USDC returns `isFixedRate: false` with a genuine gap between `currencyOut.amount` and `currencyOut.minimumAmount`:

```
amount        = 1758580426
minimumAmount = 1740994621   → ~1.000% gap
```

Copying `expectedOutput` into `MinimumOutput` hands every caller a permanently **false zero-slippage floor**. Any pre-sign card, slippage-risk warning, or downstream check that reads `Quote.MinimumOutput` shows "no downside" for a swap that can actually settle ~1% lower than expected.

## how

Add `minimumAmount` to the `relayCurrencyOut` response struct and use it as `MinimumOutput`, falling back to `expectedOutput` only when the API omits the field. Regression test (httptest with distinct `amount`/`minimumAmount`) asserts `MinimumOutput` tracks `minimumAmount` and falls back safely when absent.

## risk

Low, strictly corrective — `MinimumOutput` now reflects the API's real floor instead of an optimistic copy. `go build ./sdk/swap/` + `go vet` clean; test passes under the go.mod toolchain (`GOTOOLCHAIN=go1.24.2` — the package test binary doesn't link on Go >=1.24 due to a pinned `bytedance/sonic`/`go:linkname` issue, unrelated to this change).

## receipts

Field + gap live-verified against the production Relay API (curl above). Found by a fund-safety audit of the recipes swap providers (the same audit that surfaced the MayaChain zero-slippage CRITICAL, recipes#597). Related lower-severity findings from that audit (Relay ignoring an explicit `AffiliateBps: 0` opt-out; 1inch/Jupiter/LiFi/Uniswap not forwarding `req.ToleranceBps`) are being triaged separately.
