### PR TITLE
fix(swap): forward caller slippage to jupiter instead of hardcoded 1%

### DIFF
--- a/sdk/swap/jupiter.go
+++ b/sdk/swap/jupiter.go
@@ -80,12 +80,23 @@ func (p *JupiterProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quot
 	}
 
 	// Build quote URL
+	// Honor the caller's requested slippage. Jupiter's slippageBps is in the
+	// same basis-point units as QuoteRequest.ToleranceBps, and it bakes the
+	// resulting min-out into the quote's otherAmountThreshold (carried through
+	// to BuildTx via ProviderData) — so forwarding a positive tolerance here is
+	// sufficient. Fall back to the 1% default when the caller omits it (or
+	// passes 0, which would demand exact-out and revert on any movement).
+	slippageBps := jupiterDefaultSlippage
+	if req.ToleranceBps != nil && *req.ToleranceBps > 0 {
+		slippageBps = *req.ToleranceBps
+	}
+
 	params := url.Values{}
 	params.Set("swapMode", "ExactIn")
 	params.Set("inputMint", inputMint)
 	params.Set("outputMint", outputMint)
 	params.Set("amount", req.Amount.String())
-	params.Set("slippageBps", fmt.Sprintf("%d", jupiterDefaultSlippage))
+	params.Set("slippageBps", fmt.Sprintf("%d", slippageBps))
 
 	quoteURL := fmt.Sprintf("%s/swap/v1/quote?%s", p.apiURL, params.Encode())
 

--- a/sdk/swap/jupiter_tolerance_test.go
+++ b/sdk/swap/jupiter_tolerance_test.go
@@ -1,0 +1,68 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// Regression: JupiterProvider.GetQuote must forward the caller's requested
+// slippage (QuoteRequest.ToleranceBps) as slippageBps rather than always
+// sending the hardcoded 1% default, so a caller can tighten or loosen the
+// swap's min-out (baked into otherAmountThreshold).
+func TestJupiterGetQuoteForwardsToleranceBps(t *testing.T) {
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		_, _ = w.Write([]byte(`{"outAmount":"1000000","otherAmountThreshold":"990000","routePlan":[]}`))
+	}))
+	defer srv.Close()
+
+	p := NewJupiterProvider(srv.URL)
+	base := QuoteRequest{
+		From:        Asset{Chain: "Solana", Symbol: "SOL", Decimals: 9},
+		To:          Asset{Chain: "Solana", Symbol: "USDC", Address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", Decimals: 6},
+		Amount:      big.NewInt(1_000_000_000),
+		Destination: "So11111111111111111111111111111111111111112",
+		Sender:      "So11111111111111111111111111111111111111112",
+	}
+
+	t.Run("explicit tolerance forwarded", func(t *testing.T) {
+		captured = nil
+		tol := 250
+		req := base
+		req.ToleranceBps = &tol
+		if _, err := p.GetQuote(context.Background(), req); err != nil {
+			t.Fatalf("GetQuote: %v", err)
+		}
+		if got := captured.Get("slippageBps"); got != "250" {
+			t.Errorf("slippageBps = %q, want 250", got)
+		}
+	})
+
+	t.Run("omitted tolerance uses 1% default", func(t *testing.T) {
+		captured = nil
+		if _, err := p.GetQuote(context.Background(), base); err != nil {
+			t.Fatalf("GetQuote: %v", err)
+		}
+		if got := captured.Get("slippageBps"); got != "100" {
+			t.Errorf("default slippageBps = %q, want 100", got)
+		}
+	})
+
+	t.Run("zero tolerance falls back to default (not exact-out)", func(t *testing.T) {
+		captured = nil
+		zero := 0
+		req := base
+		req.ToleranceBps = &zero
+		if _, err := p.GetQuote(context.Background(), req); err != nil {
+			t.Fatalf("GetQuote: %v", err)
+		}
+		if got := captured.Get("slippageBps"); got != "100" {
+			t.Errorf("zero-tolerance slippageBps = %q, want 100 (fallback)", got)
+		}
+	})
+}


### PR DESCRIPTION
## what

`JupiterProvider.GetQuote` always sent `slippageBps=100` (the 1% default) and ignored `QuoteRequest.ToleranceBps` entirely — a caller could neither tighten (e.g. 0.3% for a deep pool) nor loosen (e.g. 3% for a volatile one) the swap's slippage. Not a fund-loss (1% is a sane floor), but the requested tolerance was silently dropped.

## how

Jupiter bakes the resulting min-out into the quote's `otherAmountThreshold`, which is cached in `ProviderData` and reused by `BuildTx` — so forwarding a positive tolerance at the quote call is sufficient (single-site fix). Honor `req.ToleranceBps` (same basis-point units) when positive; fall back to the 1% default when omitted or 0 (0 would demand exact-out and revert on any price movement). Regression test asserts the outgoing `slippageBps` tracks the requested tolerance, defaults to 100 when omitted, and falls back on 0.

## risk

Low — default behavior is unchanged; only an explicit positive tolerance now takes effect. `go build ./sdk/swap/` + `go vet` clean; test passes under the go.mod toolchain (`GOTOOLCHAIN=go1.24.2` — the package test binary doesn't link on Go >=1.24 due to a pinned `bytedance/sonic`/`go:linkname` issue, unrelated to this change).

## receipts

Found by the recipes swap-providers fund-safety audit (the MayaChain-CRITICAL / Relay-min-out vein — recipes#597, #598). Sibling finding: **1inch** (`oneinch.go`) has the same hardcoded-1% ignore-tolerance behavior but threads slippage at two sites (quote + BuildTx) and needs the tolerance carried through `SwapRequest`/`Quote`, so it's left for a follow-up. LiFi's omitted-slippage default was live-verified conservative (0.5%).
