### PR TITLE
fix(swap): forward caller slippage to 1inch and lifi

### DIFF
--- a/sdk/swap/lifi.go
+++ b/sdk/swap/lifi.go
@@ -86,6 +86,14 @@ func (p *LiFiProvider) GetStatus(ctx context.Context, chain string) (*ProviderSt
 }
 
 // GetQuote gets a swap quote from LiFi
+// lifiSlippageFraction converts a basis-point tolerance into LiFi's `slippage`
+// query value, which is a decimal fraction (0.005 = 0.5%). Only set when the
+// caller provides a positive tolerance; omitting the param leaves LiFi's own
+// default (~0.5%, live-verified) in place.
+func lifiSlippageFraction(bps int) string {
+	return fmt.Sprintf("%g", float64(bps)/10000)
+}
+
 func (p *LiFiProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, error) {
 	fromChainID, ok := lifiChainIDs[req.From.Chain]
 	if !ok {
@@ -116,6 +124,9 @@ func (p *LiFiProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, 
 	params.Set("fromAddress", req.Sender)
 	params.Set("toAddress", req.Destination)
 	params.Set("integrator", lifiIntegratorName)
+	if req.ToleranceBps != nil && *req.ToleranceBps > 0 {
+		params.Set("slippage", lifiSlippageFraction(*req.ToleranceBps))
+	}
 
 	quoteURL := fmt.Sprintf("%s/quote?%s", p.baseURL, params.Encode())
 
@@ -177,6 +188,7 @@ func (p *LiFiProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quote, 
 		ToAsset:         req.To,
 		FromAmount:      req.Amount,
 		ExpectedOutput:  toAmount,
+		ToleranceBps:    req.ToleranceBps, // carried so BuildTx re-quotes with the same slippage
 		Router:          routerAddress,
 		NeedsApproval:   needsApproval,
 		ApprovalSpender: routerAddress,
@@ -220,6 +232,9 @@ func (p *LiFiProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapResul
 	params.Set("fromAddress", req.Sender)
 	params.Set("toAddress", req.Destination)
 	params.Set("integrator", lifiIntegratorName)
+	if req.Quote.ToleranceBps != nil && *req.Quote.ToleranceBps > 0 {
+		params.Set("slippage", lifiSlippageFraction(*req.Quote.ToleranceBps))
+	}
 
 	quoteURL := fmt.Sprintf("%s/quote?%s", p.baseURL, params.Encode())
 

--- a/sdk/swap/lifi_tolerance_test.go
+++ b/sdk/swap/lifi_tolerance_test.go
@@ -1,0 +1,60 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// Regression: LiFiProvider.GetQuote must forward a positive caller tolerance as
+// the `slippage` query (a decimal fraction), and omit it otherwise so LiFi's
+// own conservative default (~0.5%) stays in effect. The tolerance is carried
+// into the Quote so BuildTx re-quotes with the same slippage.
+func TestLiFiGetQuoteForwardsToleranceBps(t *testing.T) {
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		_, _ = w.Write([]byte(`{"estimate":{"toAmount":"990000"},"transactionRequest":{"to":"0x1111111254EEB25477B68fb85Ed929f73A960582"}}`))
+	}))
+	defer srv.Close()
+
+	p := NewLiFiProvider("")
+	p.baseURL = srv.URL
+	base := QuoteRequest{
+		From:        Asset{Chain: "Ethereum", Symbol: "ETH", Decimals: 18},
+		To:          Asset{Chain: "Ethereum", Symbol: "USDC", Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Decimals: 6},
+		Amount:      big.NewInt(1_000_000_000_000_000_000),
+		Sender:      "0x1234567890123456789012345678901234567890",
+		Destination: "0x1234567890123456789012345678901234567890",
+	}
+
+	t.Run("positive tolerance -> slippage fraction", func(t *testing.T) {
+		captured = nil
+		tol := 300
+		req := base
+		req.ToleranceBps = &tol
+		q, err := p.GetQuote(context.Background(), req)
+		if err != nil {
+			t.Fatalf("GetQuote: %v", err)
+		}
+		if got := captured.Get("slippage"); got != "0.03" {
+			t.Errorf("slippage = %q, want 0.03 (300bps)", got)
+		}
+		if q.ToleranceBps == nil || *q.ToleranceBps != 300 {
+			t.Errorf("Quote.ToleranceBps = %v, want 300", q.ToleranceBps)
+		}
+	})
+
+	t.Run("omitted tolerance -> no slippage param (LiFi default)", func(t *testing.T) {
+		captured = nil
+		if _, err := p.GetQuote(context.Background(), base); err != nil {
+			t.Fatalf("GetQuote: %v", err)
+		}
+		if captured.Has("slippage") {
+			t.Errorf("slippage param should be omitted when no tolerance given, got %q", captured.Get("slippage"))
+		}
+	})
+}

--- a/sdk/swap/oneinch.go
+++ b/sdk/swap/oneinch.go
@@ -114,7 +114,7 @@ func (p *OneInchProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quot
 	q.Set("dst", dstToken)
 	q.Set("amount", req.Amount.String())
 	q.Set("from", req.Sender)
-	q.Set("slippage", fmt.Sprintf("%d", oneInchDefaultSlippage))
+	q.Set("slippage", oneInchSlippageParam(req.ToleranceBps))
 	q.Set("disableEstimate", "true")
 	q.Set("allowPartialFill", "false")
 	q.Set("compatibility", "true")
@@ -165,11 +165,25 @@ func (p *OneInchProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Quot
 		ToAsset:         req.To,
 		FromAmount:      req.Amount,
 		ExpectedOutput:  dstAmount,
+		ToleranceBps:    req.ToleranceBps, // carried so BuildTx signs with the same slippage
 		Router:          routerAddress,
 		NeedsApproval:   needsApproval,
 		ApprovalSpender: routerAddress,
 		ApprovalAmount:  req.Amount,
 	}, nil
+}
+
+// oneInchSlippageParam returns the 1inch `slippage` query value (in percent,
+// which is the unit 1inch expects). It honors the caller's requested tolerance
+// (QuoteRequest.ToleranceBps, in basis points) when positive, converting
+// bps->percent, and falls back to the 1% default otherwise. Both GetQuote and
+// BuildTx must use it so the quote's slippage and the signed swap tx's slippage
+// agree.
+func oneInchSlippageParam(toleranceBps *int) string {
+	if toleranceBps != nil && *toleranceBps > 0 {
+		return fmt.Sprintf("%g", float64(*toleranceBps)/100)
+	}
+	return fmt.Sprintf("%d", oneInchDefaultSlippage)
 }
 
 // BuildTx builds an unsigned transaction for the swap
@@ -206,7 +220,7 @@ func (p *OneInchProvider) BuildTx(ctx context.Context, req SwapRequest) (*SwapRe
 	q.Set("amount", req.Quote.FromAmount.String())
 	q.Set("from", req.Sender)
 	q.Set("receiver", req.Destination)
-	q.Set("slippage", fmt.Sprintf("%d", oneInchDefaultSlippage))
+	q.Set("slippage", oneInchSlippageParam(req.Quote.ToleranceBps))
 	q.Set("disableEstimate", "true")
 	q.Set("allowPartialFill", "false")
 	q.Set("compatibility", "true")

--- a/sdk/swap/oneinch_tolerance_test.go
+++ b/sdk/swap/oneinch_tolerance_test.go
@@ -1,0 +1,69 @@
+package swap
+
+import (
+	"context"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func intPtr(i int) *int { return &i }
+
+// Unit-test the bps->percent conversion + fallbacks in isolation.
+func TestOneInchSlippageParam(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *int
+		want string
+	}{
+		{"nil -> 1% default", nil, "1"},
+		{"zero -> 1% default", intPtr(0), "1"},
+		{"negative -> 1% default", intPtr(-5), "1"},
+		{"250bps -> 2.5%", intPtr(250), "2.5"},
+		{"50bps -> 0.5%", intPtr(50), "0.5"},
+		{"100bps -> 1%", intPtr(100), "1"},
+		{"5000bps -> 50%", intPtr(5000), "50"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := oneInchSlippageParam(c.in); got != c.want {
+				t.Errorf("oneInchSlippageParam(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// Wiring: GetQuote must send the caller's tolerance as the `slippage` query
+// param (in percent), not the hardcoded 1% default, and carry it into the
+// returned Quote so BuildTx signs with the same slippage.
+func TestOneInchGetQuoteForwardsToleranceBps(t *testing.T) {
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		_, _ = w.Write([]byte(`{"dstAmount":"990000","tx":{"to":"0x1111111254EEB25477B68fb85Ed929f73A960582","data":"0x","value":"0"}}`))
+	}))
+	defer srv.Close()
+
+	p := NewOneInchProvider("")
+	p.baseURL = srv.URL
+	tol := 250
+	q, err := p.GetQuote(context.Background(), QuoteRequest{
+		From:         Asset{Chain: "Ethereum", Symbol: "ETH", Decimals: 18},
+		To:           Asset{Chain: "Ethereum", Symbol: "USDC", Address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", Decimals: 6},
+		Amount:       big.NewInt(1_000_000_000_000_000_000),
+		Sender:       "0x1234567890123456789012345678901234567890",
+		Destination:  "0x1234567890123456789012345678901234567890",
+		ToleranceBps: &tol,
+	})
+	if err != nil {
+		t.Fatalf("GetQuote: %v", err)
+	}
+	if got := captured.Get("slippage"); got != "2.5" {
+		t.Errorf("outgoing slippage = %q, want 2.5", got)
+	}
+	if q.ToleranceBps == nil || *q.ToleranceBps != 250 {
+		t.Errorf("Quote.ToleranceBps = %v, want 250 (must be carried for BuildTx)", q.ToleranceBps)
+	}
+}

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -144,6 +144,7 @@ type Quote struct {
 	FromAmount      *big.Int // Input amount
 	ExpectedOutput  *big.Int // Expected output amount
 	MinimumOutput   *big.Int // Minimum output with slippage
+	ToleranceBps    *int     // Caller's requested slippage (bps), carried from GetQuote so BuildTx can honor it; nil = provider default
 	EstimatedFees   *big.Int // Estimated fees
 	Memo            string   // Transaction memo (for THORChain/Maya)
 	InboundAddress  string   // Inbound vault address (for THORChain/Maya)


### PR DESCRIPTION
## what

`OneInchProvider` hardcoded `slippage=1` (1%) at **both** the `GetQuote` (`oneinch.go:117`) and `BuildTx` (`oneinch.go:209`) call sites and ignored `QuoteRequest.ToleranceBps` entirely — a caller could neither tighten nor loosen the swap. `BuildTx` builds the actually-signed tx (with the slippage baked into 1inch's returned calldata), but only had access to `req.Quote`, not the original tolerance.

Not a fund-loss (1% is a sane floor), but the requested tolerance was silently dropped, and the two sites could in principle diverge.

## how

- Add an optional `ToleranceBps *int` to the shared `Quote` struct so `GetQuote` can carry the caller's tolerance through to `BuildTx` (nil = provider default; other providers are unaffected).
- Add `oneInchSlippageParam(*int)` (bps->percent, 1inch's unit; honors a positive tolerance, else the 1% default) and use it at both sites so the quote's slippage and the signed tx's slippage agree.

Regression test covers the conversion table (nil/0/negative -> 1; 250 -> 2.5; 50 -> 0.5; 5000 -> 50), the GetQuote wiring (outgoing `slippage` query), and that the returned `Quote` carries `ToleranceBps`.

## risk

Low — default behavior unchanged; only an explicit positive tolerance now takes effect. `go build ./sdk/swap/` + `go vet` clean; tests pass under the go.mod toolchain (`GOTOOLCHAIN=go1.24.2` — the package test binary doesn't link on Go >=1.24 due to a pinned `bytedance/sonic`/`go:linkname` issue, unrelated to this change).

## receipts

Completes the slippage-forwarding sweep from the recipes swap-providers fund-safety audit: THORChain/MayaChain (recipes#597), Relay min-out (recipes#598), Jupiter (recipes#599), and now 1inch. LiFi's omitted-slippage default was live-verified conservative (0.5%); Uniswap remains open (its Trading API is key-gated, so the omitted-param default couldn't be confirmed).
