### PR TITLE
fix(revenue): thread THORChain/Mayachain affiliate in Go recipes swap path (Station fee dropped)

### DIFF
--- a/sdk/swap/affiliate_test.go
+++ b/sdk/swap/affiliate_test.go
@@ -1,0 +1,257 @@
+package swap
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// stationAffiliateAddress / stationAffiliateBps mirror the values Station
+// (money.terra.station) uses on the TS stack (agent-backend-ts
+// STATION_AFFILIATE_CONFIG.native): affiliateFeeAddress='stvs', 50 bps
+// (baseAffiliateBps in vultisig-sdk/packages/core/chain/swap/affiliate/config.ts).
+// Test-local constants — callers select the real values, this package only
+// threads whatever it's given.
+const (
+	stationAffiliateAddress = "stvs"
+	stationAffiliateBps     = 50
+	defaultAffiliateAddress = "v0"
+	defaultAffiliateBps     = 50
+)
+
+// newThorQuoteStub starts an httptest server that echoes the request's query
+// params back as the memo, so tests can assert on exactly what the provider
+// sent without depending on real THORChain/Maya endpoints.
+func newThorQuoteStub(t *testing.T) (*httptest.Server, *url.Values) {
+	t.Helper()
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		resp := thorChainQuoteResponse{
+			InboundAddress:    "thor1inboundvault",
+			Router:            "",
+			Expiry:            1234567890,
+			Memo:              "=:ETH.ETH:0xdest:0",
+			ExpectedAmountOut: "100000000",
+		}
+		if a := captured.Get("affiliate"); a != "" {
+			resp.Memo = "=:ETH.ETH:0xdest:0:" + a + ":" + captured.Get("affiliate_bps")
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &captured
+}
+
+func newMayaQuoteStub(t *testing.T) (*httptest.Server, *url.Values) {
+	t.Helper()
+	var captured url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		resp := mayaChainQuoteResponse{
+			InboundAddress:    "maya1inboundvault",
+			Router:            "",
+			Expiry:            1234567890,
+			Memo:              "=:ETH.ETH:0xdest:0",
+			ExpectedAmountOut: "100000000",
+		}
+		if a := captured.Get("affiliate"); a != "" {
+			resp.Memo = "=:ETH.ETH:0xdest:0:" + a + ":" + captured.Get("affiliate_bps")
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &captured
+}
+
+func ethAsset() Asset   { return Asset{Chain: "Ethereum", Symbol: "ETH", Decimals: 18} }
+func rune_() Asset      { return Asset{Chain: "THORChain", Symbol: "RUNE", Decimals: 8} }
+func cacaoAsset() Asset { return Asset{Chain: "MayaChain", Symbol: "CACAO", Decimals: 10} }
+
+// (a) Station-app THOR swap: quote carries the Station affiliate (stvs, 50bps).
+func TestTHORChainGetQuote_StationAffiliate(t *testing.T) {
+	srv, captured := newThorQuoteStub(t)
+	provider := NewTHORChainProvider([]string{srv.URL})
+
+	bps := stationAffiliateBps
+	req := QuoteRequest{
+		From:             rune_(),
+		To:               ethAsset(),
+		Amount:           big.NewInt(1_000_000_000),
+		Destination:      "0xdest",
+		AffiliateAddress: stationAffiliateAddress,
+		AffiliateBps:     &bps,
+	}
+
+	quote, err := provider.GetQuote(t.Context(), req)
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if got := captured.Get("affiliate"); got != stationAffiliateAddress {
+		t.Errorf("affiliate param: got %q, want %q", got, stationAffiliateAddress)
+	}
+	if got := captured.Get("affiliate_bps"); got != "50" {
+		t.Errorf("affiliate_bps param: got %q, want %q", got, "50")
+	}
+	if quote.Memo == "" {
+		t.Fatal("expected non-empty memo")
+	}
+}
+
+// (b) non-station/vultisig default THOR swap: carries the default affiliate (v0, 50bps).
+func TestTHORChainGetQuote_DefaultAffiliate(t *testing.T) {
+	srv, captured := newThorQuoteStub(t)
+	provider := NewTHORChainProvider([]string{srv.URL})
+
+	bps := defaultAffiliateBps
+	req := QuoteRequest{
+		From:             ethAsset(),
+		To:               rune_(),
+		Amount:           big.NewInt(1_000_000_000_000_000_000),
+		Destination:      "thor1dest",
+		AffiliateAddress: defaultAffiliateAddress,
+		AffiliateBps:     &bps,
+	}
+
+	_, err := provider.GetQuote(t.Context(), req)
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if got := captured.Get("affiliate"); got != defaultAffiliateAddress {
+		t.Errorf("affiliate param: got %q, want %q", got, defaultAffiliateAddress)
+	}
+	if got := captured.Get("affiliate_bps"); got != "50" {
+		t.Errorf("affiliate_bps param: got %q, want %q", got, "50")
+	}
+}
+
+// Fail-closed: no affiliate fields set on the request → no affiliate params
+// sent at all (bare memo), never a silent default.
+func TestTHORChainGetQuote_NoAffiliateWhenUnset(t *testing.T) {
+	srv, captured := newThorQuoteStub(t)
+	provider := NewTHORChainProvider([]string{srv.URL})
+
+	req := QuoteRequest{
+		From:        rune_(),
+		To:          ethAsset(),
+		Amount:      big.NewInt(1_000_000_000),
+		Destination: "0xdest",
+	}
+
+	_, err := provider.GetQuote(t.Context(), req)
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if captured.Has("affiliate") {
+		t.Errorf("expected no affiliate param when unset, got %q", captured.Get("affiliate"))
+	}
+	if captured.Has("affiliate_bps") {
+		t.Errorf("expected no affiliate_bps param when unset, got %q", captured.Get("affiliate_bps"))
+	}
+}
+
+// Mayachain mirrors the THORChain behaviour — same wiring gap, same fix.
+func TestMayachainGetQuote_StationAffiliate(t *testing.T) {
+	srv, captured := newMayaQuoteStub(t)
+	provider := NewMayachainProvider([]string{srv.URL})
+
+	bps := stationAffiliateBps
+	req := QuoteRequest{
+		From:             cacaoAsset(),
+		To:               ethAsset(),
+		Amount:           big.NewInt(10_000_000_000_000),
+		Destination:      "0xdest",
+		AffiliateAddress: stationAffiliateAddress,
+		AffiliateBps:     &bps,
+	}
+
+	_, err := provider.GetQuote(t.Context(), req)
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if got := captured.Get("affiliate"); got != stationAffiliateAddress {
+		t.Errorf("affiliate param: got %q, want %q", got, stationAffiliateAddress)
+	}
+	if got := captured.Get("affiliate_bps"); got != "50" {
+		t.Errorf("affiliate_bps param: got %q, want %q", got, "50")
+	}
+}
+
+func TestMayachainGetQuote_NoAffiliateWhenUnset(t *testing.T) {
+	srv, captured := newMayaQuoteStub(t)
+	provider := NewMayachainProvider([]string{srv.URL})
+
+	req := QuoteRequest{
+		From:        cacaoAsset(),
+		To:          ethAsset(),
+		Amount:      big.NewInt(10_000_000_000_000),
+		Destination: "0xdest",
+	}
+
+	_, err := provider.GetQuote(t.Context(), req)
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if captured.Has("affiliate") {
+		t.Errorf("expected no affiliate param when unset, got %q", captured.Get("affiliate"))
+	}
+}
+
+// (c) the memo format matches what THORChain expects:
+// =:ASSET:ADDR:LIM:AFFILIATE:BPS
+func TestSetAffiliateParams_MemoFormat(t *testing.T) {
+	params := url.Values{}
+	bps := stationAffiliateBps
+	req := QuoteRequest{AffiliateAddress: stationAffiliateAddress, AffiliateBps: &bps}
+	setAffiliateParams(params, req)
+
+	// Simulate the THOR-style memo the inbound vault/thornode would build
+	// once affiliate+affiliate_bps are present on the quote request.
+	memo := "=:ETH.ETH:0xdest:149818:" + params.Get("affiliate") + ":" + params.Get("affiliate_bps")
+	want := "=:ETH.ETH:0xdest:149818:stvs:50"
+	if memo != want {
+		t.Errorf("memo format: got %q, want %q", memo, want)
+	}
+}
+
+// Explicit zero bps is treated the same as unset (no affiliate line) — a
+// caller passing AffiliateBps=0 is signalling "no fee", not "0% but still
+// attribute to me".
+func TestSetAffiliateParams_ZeroBpsOmitted(t *testing.T) {
+	params := url.Values{}
+	zero := 0
+	req := QuoteRequest{AffiliateAddress: stationAffiliateAddress, AffiliateBps: &zero}
+	setAffiliateParams(params, req)
+
+	if params.Has("affiliate") || params.Has("affiliate_bps") {
+		t.Errorf("expected no affiliate params for zero bps, got affiliate=%q affiliate_bps=%q",
+			params.Get("affiliate"), params.Get("affiliate_bps"))
+	}
+}
+
+// AffiliateAddress set but AffiliateBps nil (or vice versa) — fail closed,
+// no partial affiliate line.
+func TestSetAffiliateParams_PartialFieldsOmitted(t *testing.T) {
+	params := url.Values{}
+	req := QuoteRequest{AffiliateAddress: stationAffiliateAddress, AffiliateBps: nil}
+	setAffiliateParams(params, req)
+	if params.Has("affiliate") {
+		t.Errorf("expected no affiliate param when bps is nil, got %q", params.Get("affiliate"))
+	}
+
+	params2 := url.Values{}
+	bps := stationAffiliateBps
+	req2 := QuoteRequest{AffiliateAddress: "", AffiliateBps: &bps}
+	setAffiliateParams(params2, req2)
+	if params2.Has("affiliate_bps") {
+		t.Errorf("expected no affiliate_bps param when address is empty, got %q", params2.Get("affiliate_bps"))
+	}
+}

--- a/sdk/swap/affiliate_test.go
+++ b/sdk/swap/affiliate_test.go
@@ -237,6 +237,20 @@ func TestSetAffiliateParams_ZeroBpsOmitted(t *testing.T) {
 	}
 }
 
+// Out-of-range bps (>10000 = >100%) is rejected client-side rather than
+// sent to thornode/maya, mirroring the toleranceBps bound-check.
+func TestSetAffiliateParams_OutOfRangeBpsOmitted(t *testing.T) {
+	params := url.Values{}
+	tooHigh := 10001
+	req := QuoteRequest{AffiliateAddress: stationAffiliateAddress, AffiliateBps: &tooHigh}
+	setAffiliateParams(params, req)
+
+	if params.Has("affiliate") || params.Has("affiliate_bps") {
+		t.Errorf("expected no affiliate params for out-of-range bps, got affiliate=%q affiliate_bps=%q",
+			params.Get("affiliate"), params.Get("affiliate_bps"))
+	}
+}
+
 // AffiliateAddress set but AffiliateBps nil (or vice versa) — fail closed,
 // no partial affiliate line.
 func TestSetAffiliateParams_PartialFieldsOmitted(t *testing.T) {

--- a/sdk/swap/mayachain.go
+++ b/sdk/swap/mayachain.go
@@ -188,6 +188,7 @@ func (p *MayachainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 	params.Set("destination", req.Destination)
 	params.Set("streaming_interval", "3")
 	params.Set("streaming_quantity", "0")
+	setAffiliateParams(params, req)
 
 	// Try all endpoints with fallback
 	var lastErr error

--- a/sdk/swap/service.go
+++ b/sdk/swap/service.go
@@ -53,6 +53,14 @@ type SwapParams struct {
 	// If nil, uses default provider order.
 	Preference   *ProviderPreference
 	ToleranceBps *int // Optional THOR/Maya quote tolerance override in basis points (typically 0-10000, where 10000 = 100%)
+
+	// AffiliateBps / AffiliateAddress set the THOR/Maya affiliate fee on the
+	// quote request (see QuoteRequest for the full contract). Both must be
+	// set for an affiliate to be attached; leaving them unset fails closed
+	// (bare memo, no affiliate) rather than silently defaulting to some
+	// party's fee address.
+	AffiliateBps     *int
+	AffiliateAddress string
 }
 
 // SwapTx contains the transaction data ready for signing.
@@ -103,6 +111,9 @@ func (s *Service) GetSwapTx(ctx context.Context, params SwapParams) (*SwapTx, er
 		Destination:  params.Destination,
 		ToleranceBps: params.ToleranceBps,
 		Preference:   params.Preference,
+
+		AffiliateBps:     params.AffiliateBps,
+		AffiliateAddress: params.AffiliateAddress,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quote: %w", err)
@@ -314,6 +325,9 @@ func (s *Service) GetSwapTxBundle(ctx context.Context, params SwapParams) (*Swap
 		Destination:  params.Destination,
 		ToleranceBps: params.ToleranceBps,
 		Preference:   params.Preference,
+
+		AffiliateBps:     params.AffiliateBps,
+		AffiliateAddress: params.AffiliateAddress,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get quote: %w", err)
@@ -367,6 +381,9 @@ func (s *Service) GetQuote(ctx context.Context, params SwapParams) (*Quote, erro
 		Destination:  params.Destination,
 		ToleranceBps: params.ToleranceBps,
 		Preference:   params.Preference,
+
+		AffiliateBps:     params.AffiliateBps,
+		AffiliateAddress: params.AffiliateAddress,
 	})
 }
 

--- a/sdk/swap/thorchain.go
+++ b/sdk/swap/thorchain.go
@@ -209,6 +209,7 @@ func (p *THORChainProvider) GetQuote(ctx context.Context, req QuoteRequest) (*Qu
 		return nil, fmt.Errorf("invalid tolerance_bps %d: must be between 0 and 10000", toleranceBps)
 	}
 	params.Set("tolerance_bps", fmt.Sprintf("%d", toleranceBps))
+	setAffiliateParams(params, req)
 
 	// Try all endpoints with fallback
 	var lastErr error

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -222,6 +222,13 @@ func setAffiliateParams(params url.Values, req QuoteRequest) {
 	if req.AffiliateAddress == "" || req.AffiliateBps == nil || *req.AffiliateBps <= 0 {
 		return
 	}
+	// Bound-check like toleranceBps above: a caller-supplied bps outside
+	// THORChain/Maya's valid range (0-10000, where 10000 = 100%) should fail
+	// fast client-side rather than go out on the wire and let thornode/maya
+	// reject or misinterpret it.
+	if *req.AffiliateBps > 10000 {
+		return
+	}
 	params.Set("affiliate", req.AffiliateAddress)
 	params.Set("affiliate_bps", fmt.Sprintf("%d", *req.AffiliateBps))
 }

--- a/sdk/swap/types.go
+++ b/sdk/swap/types.go
@@ -2,7 +2,9 @@ package swap
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"net/url"
 )
 
 // Asset represents a token/coin on a specific chain
@@ -200,6 +202,28 @@ type ProviderStatus struct {
 	ChainTradingPaused  bool
 	Router              string
 	InboundAddress      string
+}
+
+// setAffiliateParams sets the THORChain/Mayachain-style `affiliate` /
+// `affiliate_bps` quote query params from req.AffiliateAddress /
+// req.AffiliateBps, mirroring the SDK's buildAffiliateParams
+// (vultisig-sdk/packages/core/chain/swap/native/api/affiliate.ts). Both the
+// THORChain and Mayachain `/quote/swap` REST APIs accept the same two params.
+//
+// Before this helper existed, req.AffiliateBps / req.AffiliateAddress were
+// declared on QuoteRequest but silently dropped by both native providers —
+// every THOR/Maya swap built through this package went out with NO
+// affiliate, losing the caller's affiliate fee attribution entirely
+// (vultisig/agent-backend revenue bug, 2026-07-09). Callers MUST set
+// AffiliateAddress explicitly; this helper does not invent a default so a
+// caller who forgets to set it fails closed (no affiliate line in the memo)
+// rather than silently misattributing the fee to some other party.
+func setAffiliateParams(params url.Values, req QuoteRequest) {
+	if req.AffiliateAddress == "" || req.AffiliateBps == nil || *req.AffiliateBps <= 0 {
+		return
+	}
+	params.Set("affiliate", req.AffiliateAddress)
+	params.Set("affiliate_bps", fmt.Sprintf("%d", *req.AffiliateBps))
 }
 
 // EVMChains is the list of EVM-compatible chains that support ERC20 approvals


### PR DESCRIPTION
## Summary

**P1 revenue bug.** Station user paaao reported a THORChain swap (`314CAC443C23D3A180A6DABFF514A1FA1DAE0C399988B6E2C67FA4313F903317`) that lost the Station affiliate fee — got "va"/no-station instead of Station's affiliate. Root-caused in `.spikes/URGENT-swap-no-card-and-wrong-affiliate-2026-07-09.md` (BUG 2).

**abts (agent-backend-ts) is correct.** The TS stack threads Station's affiliate end-to-end and it's proven on the wire: the matching abts conversation for this exact swap built memo `=:e:0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF:834597:stvs:50` — `stvs` (Station THORName) at 50 bps. Chain: `stationAffiliateConfig.ts` → `execute_swap.ts:2558` → SDK `findSwapQuote.ts:626` → `getNativeSwapQuote.ts:85` → `affiliate.ts:34`.

**Root cause (this repo).** `recipes/sdk/swap/thorchain.go` (`GetQuote`, quote-request builder) and `recipes/sdk/swap/mayachain.go` (`GetQuote`) build the THOR/Maya quote request but never read `QuoteRequest.AffiliateBps` / `AffiliateAddress` — both fields are declared on the struct (`types.go`) but were **silently dropped** by every native provider. Any THOR/Maya swap built through this shared Go engine goes out with a bare memo and no affiliate attribution at all, regardless of which app/deployment is calling it.

## The fix

- New `setAffiliateParams(params url.Values, req QuoteRequest)` helper (`sdk/swap/types.go`) sets THORChain/Mayachain's `affiliate` / `affiliate_bps` query params — the same two params the SDK's `buildAffiliateParams` uses — **only** when both `AffiliateAddress` and a positive, in-range (`<= 10000` bps) `AffiliateBps` are supplied. **Fails closed**: if a caller doesn't set both fields, no affiliate line is emitted (bare memo), never a silent default/misattribution.
- Called from `thorchain.go` and `mayachain.go` `GetQuote`, right after `tolerance_bps` is set.
- `SwapParams` (`sdk/swap/service.go`) gets `AffiliateBps *int` / `AffiliateAddress string`, threaded through all three `QuoteRequest{...}` construction sites (`GetSwapTx`, `GetSwapTxBundle`, `GetQuote`).

### Correct value mapping (to mirror abts exactly)
| Deployment | Affiliate thorname | bps |
|---|---|---|
| Station (money.terra.station) | `stvs` | 50 |
| Default / vultisig | `v0` | 50 |

(Source: `agent-backend-ts/.../stationAffiliateConfig.ts` `STATION_AFFILIATE_CONFIG.native.affiliateFeeAddress='stvs'`; `vultisig-sdk/.../nativeSwapAffiliateConfig.ts` default `'v0'`; `baseAffiliateBps = 50` in `vultisig-sdk/.../swap/affiliate/config.ts`.)

### Scope note — caller-side wiring is a follow-up, not this PR
`recipes/sdk/swap` is a shared library. The actual caller that builds `SwapParams` for live THOR/Maya swaps is `vultisig/mcp` (`internal/tools/execute_swap.go:247`) — a **separate repo**, imported only by `mcp`, not by `agent-backend`. Confirmed: `agent-backend` (Go) does not import `recipes` at all; and `mcp` currently has **zero app-identity concept** anywhere in its codebase (no `AppID`/`app_id`/`money.terra.station` references) — there's no existing signal at that layer for "this call is for Station." Per current architecture (`skills/common/architecture/mcp-server.md`), the Go `mcp` tool-server path is legacy and being retired in favor of abts as the prod default, which is already correct.

Given that, this PR fixes the shared engine so it **stops silently dropping affiliate fees the moment any caller does start passing them** — the fail-closed default protects against future misattribution. Wiring `mcp/internal/tools/execute_swap.go` to actually pass `stvs`/50bps (or `v0`/50bps) per-app is a follow-up change in the `mcp` repo, since it may require new app-identity plumbing through the MCP protocol boundary that's out of scope for this hotfix.

Also out of scope (separate gap, separate repo): the Skip provider (`mcp/internal/skip/client.go`) sets `cumulative_affiliate_fee_bps` but has no affiliate-address/fee-recipient field at all in `SwapArgs` — a distinct issue to file against `vultisig/mcp`.

## Tests

9 new cases in `sdk/swap/affiliate_test.go` using `httptest` stub servers (no network dependency):
- (a) Station-app THOR swap → quote carries `affiliate=stvs`, `affiliate_bps=50`
- (a) Station-app Mayachain swap → same
- (b) non-station/default THOR swap → quote carries `affiliate=v0`, `affiliate_bps=50`
- (c) memo format matches THORChain's convention `=:ASSET:ADDR:LIM:AFFILIATE:BPS`
- Fail-closed: unset both fields, zero bps, out-of-range bps (>10000), address-only, bps-only — no affiliate params sent in any of these cases

```
go test ./sdk/swap/... -v
# ok  	github.com/vultisig/recipes/sdk/swap	1.0s  (56 tests, all pass, no regressions)
go vet ./sdk/swap/...
# clean
go build ./sdk/...
# clean
```

(Note: this machine's default Go 1.26 fails to *link* this repo's test binaries due to a pre-existing `bytedance/sonic` v1.12.0 compatibility issue — unrelated to this change, reproduces identically on unmodified `main`. Built/tested with `GOTOOLCHAIN=go1.24.2` per `go.mod`'s pinned `go 1.24.2`.)

## Codex-gate verdict

**SAFE TO SHIP AS-IS**, independently re-verified (build/vet/test green). Findings addressed:
- Maya param-name parity (flagged as highest-risk assumption): confirmed via the SDK reference implementation — `getNativeSwapQuote.ts` uses the same `buildAffiliateParams()` → `{affiliate, affiliate_bps}` for both `Chain.THORChain` and `Chain.MayaChain` via the shared `NativeSwapChain` type, hitting `mayanode.../mayachain/quote/swap` in production today with identical param names. Not dead code.
- Bounds-check gap (bps > 10000) flagged and fixed in a follow-up commit (`b5a1ee3`) before this PR was opened — mirrors the existing `toleranceBps` bound-check.
- Skip-provider affiliate gap: confirmed real but out-of-scope (different repo, different code path) — flagging as a separate follow-up rather than blocking this PR.
- No regressions: `tolerance_bps`/`affiliate_bps` are independent query params, no shadowing/overwrite risk.

## QA Guide

**Intent:** Ensure the shared Go swap engine (`recipes/sdk/swap`) threads an affiliate fee into THORChain/Mayachain quote requests when a caller supplies one, and never silently drops it — closing the gap that caused Station users to lose their affiliate fee attribution on Go-built swaps.

**Verify steps:**
1. `go test ./sdk/swap/... -v -run Affiliate` — confirm all 9 new tests pass.
2. Manually construct a `QuoteRequest{AffiliateAddress: "stvs", AffiliateBps: ptr(50), ...}` for a THORChain RUNE→ETH quote and call `THORChainProvider.GetQuote` against a local httptest stub (see `affiliate_test.go` for the pattern) — confirm the outgoing HTTP request's query string contains `affiliate=stvs&affiliate_bps=50`.
3. Repeat for Mayachain (`MayachainProvider.GetQuote`).
4. Confirm a `QuoteRequest` with `AffiliateAddress`/`AffiliateBps` both zero-valued produces a request with **no** `affiliate`/`affiliate_bps` params (fail-closed check).

**Expected outcomes:** Station-configured caller values (`stvs`, 50bps) appear verbatim in the outgoing THOR/Maya quote query params; unset/zero/out-of-range values never appear.

**Edge cases (least sure about):**
- Real-network confirmation against live `thornode.thorchain.network` / `mayanode.mayachain.info` that the `affiliate`/`affiliate_bps` params are accepted and correctly reflected in the returned `memo` field — this PR's tests use a stub server that echoes params back, not the live API. A live smoke-test (once the `mcp` caller-side change lands) would close this gap.
- The Skip-provider path (different repo) is NOT covered by this fix at all — Skip-routed swaps still have no affiliate-address mechanism.

**Prereqs:** none beyond `go test` — no vault/chain/funds needed for this library-level PR (no live network calls in the test suite).

**Suggested flows:** N/A (Go unit-test level; no app/Maestro flow applies to this repo).

---

**DO NOT MERGE. DO NOT DEPLOY.** Awaiting @gomesalexandre review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap quote requests now support affiliate details for THORChain and Mayachain.
  * Quote results can include affiliate-aware memo handling when both an affiliate address and fee are provided.

* **Bug Fixes**
  * Affiliate data is now applied only when fully specified, avoiding partial or unintended affiliate attribution.
  * Invalid or out-of-range affiliate fee values are ignored to prevent malformed quotes.

* **Tests**
  * Added coverage for affiliate quote behavior across supported swap providers and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->